### PR TITLE
drop import time logging configuration

### DIFF
--- a/django_drf_filepond/apps.py
+++ b/django_drf_filepond/apps.py
@@ -5,8 +5,6 @@ import logging
 from django.conf import settings
 
 LOG = logging.getLogger(__name__)
-logging.basicConfig()
-logging.getLogger(__name__).setLevel(logging.DEBUG)
 
 class DjangoDrfFilepondConfig(AppConfig):
     name = 'django_drf_filepond'

--- a/django_drf_filepond/models.py
+++ b/django_drf_filepond/models.py
@@ -15,8 +15,6 @@ FILEPOND_UPLOAD_TMP = getattr(settings, 'DJANGO_DRF_FILEPOND_UPLOAD_TMP',
 storage = FileSystemStorage(location=FILEPOND_UPLOAD_TMP)
 
 LOG = logging.getLogger(__name__)
-logging.basicConfig()
-logging.getLogger(__name__).setLevel(logging.DEBUG)
 
 def get_upload_path(instance, filename):
     return os.path.join(instance.upload_id, filename)

--- a/django_drf_filepond/views.py
+++ b/django_drf_filepond/views.py
@@ -20,12 +20,8 @@ import shortuuid
 from django_drf_filepond.models import TemporaryUpload, storage
 from django_drf_filepond.parsers import PlainTextParser
 from django_drf_filepond.renderers import PlainTextRenderer
-import os
-
 
 LOG = logging.getLogger(__name__)
-logging.basicConfig()
-logging.getLogger(__name__).setLevel(logging.DEBUG)
 
 def _get_file_id():
     file_id = shortuuid.uuid()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,8 +15,6 @@ from django_drf_filepond import views
 
 
 LOG = logging.getLogger(__name__)
-logging.basicConfig()
-logging.getLogger(__name__).setLevel(logging.DEBUG)
 
 class AppSettingsTestCase(TestCase):
     

--- a/tests/test_fetch_view.py
+++ b/tests/test_fetch_view.py
@@ -9,8 +9,6 @@ import cgi
 
 
 LOG = logging.getLogger(__name__)
-logging.basicConfig()
-logging.getLogger(__name__).setLevel(logging.DEBUG)
 
 class FetchTestCase(TestCase):      
 

--- a/tests/test_process_view.py
+++ b/tests/test_process_view.py
@@ -13,8 +13,6 @@ from django.core.files.base import ContentFile
 from django_drf_filepond import drf_filepond_settings
 
 LOG = logging.getLogger(__name__)
-logging.basicConfig()
-logging.getLogger(__name__).setLevel(logging.DEBUG)
 
 class ProcessTestCase(TestCase):
     

--- a/tests/test_revert_view.py
+++ b/tests/test_revert_view.py
@@ -10,8 +10,6 @@ from django_drf_filepond import views
 from django_drf_filepond.models import TemporaryUpload, storage
 
 LOG = logging.getLogger(__name__)
-logging.basicConfig()
-logging.getLogger(__name__).setLevel(logging.DEBUG)
 
 class RevertTestCase(TestCase):
     

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -16,8 +16,6 @@ except ImportError:
 
 
 LOG = logging.getLogger(__name__)
-logging.basicConfig()
-logging.getLogger(__name__).setLevel(logging.DEBUG)
 
 class SignalsTestCase(TestCase):
     


### PR DESCRIPTION
Configuring logging at import time is problematic since configuration can happen before the explicit configuration done by application/django.