### PR TITLE
Removes dependency on BASE_DIR attribute in top-level app settings

### DIFF
--- a/django_drf_filepond/apps.py
+++ b/django_drf_filepond/apps.py
@@ -2,7 +2,6 @@ from django.apps import AppConfig
 
 import os
 import logging
-from django.conf import settings
 import django_drf_filepond.drf_filepond_settings as local_settings
 
 LOG = logging.getLogger(__name__)
@@ -14,7 +13,7 @@ class DjangoDrfFilepondConfig(AppConfig):
     def ready(self):
         upload_tmp = getattr(local_settings, 'UPLOAD_TMP',
                              os.path.join(
-                                 settings.BASE_DIR,'filepond_uploads'))
+                                 local_settings.BASE_DIR,'filepond_uploads'))
         LOG.debug('Upload temp directory from top level settings: <%s>'
                   % (upload_tmp))
         

--- a/django_drf_filepond/drf_filepond_settings.py
+++ b/django_drf_filepond/drf_filepond_settings.py
@@ -12,13 +12,21 @@ http://blog.muhuk.com/2010/01/26/developing-reusable-django-apps-app-settings.ht
 '''
 import os
 from django.conf import settings
+import django_drf_filepond
 
 _app_prefix = 'DJANGO_DRF_FILEPOND_'
+
+# BASE_DIR is assumed to be present in the core project settings. However,
+# in case it isn't, we check here and set a local BASE_DIR to the 
+# installed app base directory to use as an alternative.
+BASE_DIR = os.path.dirname(django_drf_filepond.__file__)
+if hasattr(settings, 'BASE_DIR'):
+    BASE_DIR = settings.BASE_DIR
 
 # The location where uploaded files are temporarily stored. At present, 
 # this must be a subdirectory of settings.BASE_DIR
 UPLOAD_TMP = getattr(settings, _app_prefix+'UPLOAD_TMP',
-                     os.path.join(settings.BASE_DIR,'filepond_uploads'))
+                     os.path.join(BASE_DIR,'filepond_uploads'))
 
 # Setting to control whether the temporary directories created for file 
 # uploads are removed when an uploaded file is deleted

--- a/django_drf_filepond/models.py
+++ b/django_drf_filepond/models.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import logging
 import os
 
-from django.conf import settings
 from django.core.files.storage import FileSystemStorage
 from django.core.validators import MinLengthValidator
 from django.db import models
@@ -16,7 +15,7 @@ import django_drf_filepond.drf_filepond_settings as local_settings
 
 FILEPOND_UPLOAD_TMP = getattr(local_settings, 'UPLOAD_TMP',
                               os.path.join(
-                                  settings.BASE_DIR,'filepond_uploads'))
+                                  local_settings.BASE_DIR,'filepond_uploads'))
 storage = FileSystemStorage(location=FILEPOND_UPLOAD_TMP)
 
 LOG = logging.getLogger(__name__)

--- a/django_drf_filepond/views.py
+++ b/django_drf_filepond/views.py
@@ -5,7 +5,6 @@ from io import BytesIO
 import logging
 
 import django_drf_filepond.drf_filepond_settings as local_settings
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import UploadedFile, InMemoryUploadedFile
 from django.core.validators import URLValidator
@@ -72,7 +71,7 @@ class ProcessView(APIView):
         # parameter that can be disabled to turn off this check if the 
         # developer wishes?
         if ((not hasattr(local_settings, 'UPLOAD_TMP')) or 
-            (not (storage.location).startswith(settings.BASE_DIR))):
+            (not (storage.location).startswith(local_settings.BASE_DIR))):
             return Response('The file upload path settings are not '
                             'configured correctly.', 
                             status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'django-drf-filepond'
-copyright = '2018, Jeremy Cohen, Imperial College London'
+copyright = '2019, Jeremy Cohen, Imperial College London'
 author = 'Jeremy Cohen'
 
 # The short X.Y version

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -43,6 +43,17 @@ variable to your settings file, e.g.::
 	DJANGO_DRF_FILEPOND_UPLOAD_TMP = os.path.join(BASE_DIR, 'filepond-temp-uploads')
 	...
 
+.. note:: It is strongly recommended that you set 
+	``DJANGO_DRF_FILEPOND_UPLOAD_TMP``. If you do not set this variable, the 
+	app will set a default location for the storage of temporary uploads. 
+	This is ``BASE_DIR/filepond_uploads`` where ``BASE_DIR`` is the variable 
+	defined by default in an auto-generated Django settings file pointing to 
+	the top-level directory of your Django project. If your settings do not 
+	contain ``BASE_DIR`` the app will default to storing the 
+	``filepond_uploads`` directory in the ``django-drf-filepond`` app  
+	directory, wherever that is located. Note that this may be within the  
+	``lib`` directory of a virtualenv.
+
 3. Include the app urls into your main url configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,23 +7,45 @@ Django project configuration, that it gets set to a sensible default.
 import logging
 import os
 
-from django.conf import settings
 from django.test import TestCase
+from django.conf import settings
+from django.utils.six.moves import reload_module
 
-from django_drf_filepond import models
 from django_drf_filepond import views
+import django_drf_filepond
+from django.test.utils import override_settings
 
+import django_drf_filepond.drf_filepond_settings as local_settings
 
 LOG = logging.getLogger(__name__)
 
 class AppSettingsTestCase(TestCase):
     
+    @classmethod
+    def tearDownClass(cls):
+        super(AppSettingsTestCase, cls).tearDownClass()
+        reload_module(local_settings)
+            
     def test_default_upload_config(self):
+        reload_module(local_settings)
+        from django_drf_filepond import models
         upload_tmp = models.storage.location
         LOG.debug('We have a settings value of: %s' % (upload_tmp))
         self.assertEqual(upload_tmp, 
-                         os.path.join(settings.BASE_DIR, 
+                         os.path.join(local_settings.BASE_DIR, 
                                       'filepond_uploads'))
+     
+    @override_settings()
+    def test_upload_config_no_base_dir(self):
+        LOG.debug('******SETTINGS.BASE_DIR: %s' % settings.BASE_DIR)
+        del settings.BASE_DIR
+        reload_module(local_settings)
+        LOG.debug('******LOCAL_SETTINGS.BASE_DIR: %s' % local_settings.BASE_DIR)
+        up_dir = os.path.join(local_settings.BASE_DIR,'filepond_uploads')
+        LOG.debug('We have a settings value of: %s' % (up_dir))
+        app_base = os.path.dirname(django_drf_filepond.__file__)
+        self.assertEqual(up_dir, 
+                         os.path.join(app_base, 'filepond_uploads'))
     
     def test_file_id(self):
         file_id = views._get_file_id()


### PR DESCRIPTION
Removes dependency on the `BASE_DIR` setting. While this is created by default when generating a Django application in 1.7+, there are cases where the configuration may not include this attribute in the settings.

Resolves issue #5