### PR TITLE
Fix for #18

### DIFF
--- a/django_drf_filepond/drf_filepond_settings.py
+++ b/django_drf_filepond/drf_filepond_settings.py
@@ -50,3 +50,11 @@ STORAGES_BACKEND = getattr(settings, _app_prefix+'STORAGES_BACKEND', None)
 # django-drf-filepond's file management and the api.store_upload function
 # will not be usable - you will need to manage file storage in your code.
 FILE_STORE_PATH = getattr(settings, _app_prefix+'FILE_STORE_PATH', None)
+
+# If you want to use an external directory (a directory outside of your 
+# project directory) to store temporary uploads, this setting needs to be 
+# set to true. By default it is False to prevent uploads being stored 
+# elsewhere.
+ALLOW_EXTERNAL_UPLOAD_DIR = getattr(settings, 
+                                    _app_prefix+'ALLOW_EXTERNAL_UPLOAD_DIR',
+                                    False)

--- a/django_drf_filepond/views.py
+++ b/django_drf_filepond/views.py
@@ -79,15 +79,29 @@ class ProcessView(APIView):
     def post(self, request):
         LOG.debug('Filepond API: Process view POST called...')
 
-        # Enforce that the upload location must be a sub-directory of
-        # the project base directory
+        # Check that the temporary upload directory has been set
+        if not hasattr(local_settings, 'UPLOAD_TMP'):
+            return Response('The file upload path settings are not '
+                            'configured correctly.',
+                            status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        # By default, enforce that the temporary upload location must be a
+        # sub-directory of the project base directory.
         # TODO: Check whether this is necessary - maybe add a security
         # parameter that can be disabled to turn off this check if the
         # developer wishes?
-        if ((not hasattr(local_settings, 'UPLOAD_TMP')) or
-                (not (storage.location).startswith(local_settings.BASE_DIR))):
-            return Response('The file upload path settings are not '
+        if not (storage.location).startswith(local_settings.BASE_DIR):
+            if not local_settings.ALLOW_EXTERNAL_UPLOAD_DIR:
+                return Response('The file upload path settings are not '
                             'configured correctly.',
+                            status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            else:
+                # Check that a relative path is not being used to store the
+                # upload outside the specified UPLOAD_TMP directory.
+                if not getattr(local_settings, 'UPLOAD_TMP').startswith(
+                        os.path.abspath(storage.location)):
+                    return Response('An invalid storage location has been '
+                            'specified.',
                             status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         # Check that we've received a file and then generate a unique ID
@@ -126,6 +140,9 @@ class ProcessView(APIView):
         #    LOG.debug('Filepond app: Creating file upload directory '
         #             '<%s>...' % storage.location)
         #    os.makedirs(storage.location, mode=0o700)
+
+        LOG.debug('About to store uploaded temp file with filename: %s' 
+                  % (upload_filename))
 
         # We now need to create the temporary upload object and store the
         # file and metadata.

--- a/django_drf_filepond/views.py
+++ b/django_drf_filepond/views.py
@@ -28,6 +28,7 @@ from django.http.response import HttpResponse, HttpResponseNotFound,\
 from django_drf_filepond.api import get_stored_upload,\
     get_stored_upload_file_data
 from django_drf_filepond.exceptions import ConfigurationError
+import django_drf_filepond
 
 LOG = logging.getLogger(__name__)
 
@@ -90,19 +91,21 @@ class ProcessView(APIView):
         # TODO: Check whether this is necessary - maybe add a security
         # parameter that can be disabled to turn off this check if the
         # developer wishes?
-        if not (storage.location).startswith(local_settings.BASE_DIR):
+        if ((not (storage.location).startswith(local_settings.BASE_DIR)) and
+                (local_settings.BASE_DIR != 
+                 os.path.dirname(django_drf_filepond.__file__))):
             if not local_settings.ALLOW_EXTERNAL_UPLOAD_DIR:
                 return Response('The file upload path settings are not '
                             'configured correctly.',
                             status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-            else:
-                # Check that a relative path is not being used to store the
-                # upload outside the specified UPLOAD_TMP directory.
-                if not getattr(local_settings, 'UPLOAD_TMP').startswith(
-                        os.path.abspath(storage.location)):
-                    return Response('An invalid storage location has been '
-                            'specified.',
-                            status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        # Check that a relative path is not being used to store the
+        # upload outside the specified UPLOAD_TMP directory.
+        if not getattr(local_settings, 'UPLOAD_TMP').startswith(
+                os.path.abspath(storage.location)):
+            return Response('An invalid storage location has been '
+                    'specified.',
+                    status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         # Check that we've received a file and then generate a unique ID
         # for it. Also generate a unique UD for the temp upload dir

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -56,6 +56,15 @@ variable to your settings file, e.g.::
 	``filepond_uploads`` directory in the ``django-drf-filepond`` app  
 	directory, wherever that is located. Note that this may be within the  
 	``lib`` directory of a virtualenv.
+	
+.. note:: If you wish to set your file upload location to an directory
+	outside of your Django application, i.e. something that is not below
+	BASE_DIR, you should consider any security implications that may result
+	from letting the app write to another location on disk and set the
+	``DJANGO_DRF_FILEPOND_ALLOW_EXTERNAL_UPLOAD_DIR`` to ``True`` to confirm
+	that you want to use a directory external to your application to store
+	temporary uploads.
+
 
 3. Include the app urls into your main url configuration
 ========================================================

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "Django<2.0.0;python_version=='2.7'",
-        "Django>=2.0.0;python_version>='3.5'",
+        "Django<3.0.0;python_version>='3.5'",
         "djangorestframework==3.9.3;python_version=='2.7'",
         "djangorestframework>=3.9.3;python_version>='3.5'",
         "shortuuid>=0.5.0",


### PR DESCRIPTION
Fixes issue with uploads not working when there is no `BASE_DIR` setting in the host application's `settings` and and upload directory outside the default base directory is specified for file uploads. See discussion in #18 for further info.