### PR TITLE
Switches user foreign keys to AUTH_USER_MODEL to support custom user models

### DIFF
--- a/django_drf_filepond/models.py
+++ b/django_drf_filepond/models.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import logging
 import os
 
+from django.conf import settings
 from django.core.files.storage import FileSystemStorage
 from django.core.validators import MinLengthValidator
 from django.db import models
@@ -93,7 +94,7 @@ class TemporaryUpload(models.Model):
     uploaded = models.DateTimeField(auto_now_add=True)
     upload_type = models.CharField(max_length=1,
                                    choices=UPLOAD_TYPE_CHOICES)
-    uploaded_by = models.ForeignKey('auth.User', null=True, blank=True,
+    uploaded_by = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True,
                                     on_delete=models.CASCADE)
 
     def get_file_path(self):
@@ -111,7 +112,7 @@ class StoredUpload(models.Model):
     file = models.FileField(storage=stored_storage, max_length=2048)
     uploaded = models.DateTimeField()
     stored = models.DateTimeField(auto_now_add=True)
-    uploaded_by = models.ForeignKey('auth.User', null=True, blank=True,
+    uploaded_by = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True,
                                     on_delete=models.CASCADE)
 
     def get_absolute_file_path(self):

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=[
         "Django>=1.11.27,<2.0.0;python_version=='2.7'",
         "Django>=2.2.9,<3.0.0;python_version=='3.5'",
-        "Django>=3.0.2;python_version>='3.6'",
+        "Django>=2.2;python_version>='3.6'",
         "djangorestframework==3.9.3;python_version=='2.7'",
         "djangorestframework>=3.9.3;python_version>='3.5'",
         "shortuuid>=0.5.0",


### PR DESCRIPTION
This addresses issue #38 by switching user foreign keys to use `settings.AUTH_USER_MODEL` rather than explicitly using `'auth.User'`. This resolves a problem with supporting custom user models.