### PR TITLE
Access file metadata

### DIFF
--- a/django_drf_filepond/uploaders.py
+++ b/django_drf_filepond/uploaders.py
@@ -63,7 +63,9 @@ class FilepondFileUploader(object):
         if upload_field_name not in request.data:
             raise ParseError('Invalid request data has been provided.')
 
-        file_obj = request.data[upload_field_name]
+        uplad_fields = request.data.getlist(upload_field_name)
+        # file_metadata = uplad_fields[0]
+        file_obj = uplad_fields[1]
 
         return file_obj
 

--- a/django_drf_filepond/uploaders.py
+++ b/django_drf_filepond/uploaders.py
@@ -63,9 +63,9 @@ class FilepondFileUploader(object):
         if upload_field_name not in request.data:
             raise ParseError('Invalid request data has been provided.')
 
-        uplad_fields = request.data.getlist(upload_field_name)
-        # file_metadata = uplad_fields[0]
-        file_obj = uplad_fields[1]
+        upload_fields = request.data.getlist(upload_field_name)
+        # file_metadata = upload_fields[0]
+        file_obj = upload_fields[1]
 
         return file_obj
 


### PR DESCRIPTION
[This](https://pqina.nl/filepond/docs/patterns/api/server/#introduction) documentation page says "Along with the file object, FilePond also sends the file metadata to the server, both these objects are given the same name." The boilerplate PHP server gets this metadata [here](https://github.com/pqina/filepond-server-php/blob/53edab832d04fe64715b483a3b469b06ecbf25c0/Helper/Transfer.class.php#L54). 

When I first looked at this code, I did not understand how the line `request.data[upload_field_name]` was able to get the file while ignoring the metadata. It turns out this is a feature of Django's `QueryDict`. [This](https://docs.djangoproject.com/en/3.0/ref/request-response/#django.http.QueryDict.__getitem__) page of Django's documentation says: "If the key has more than one value, it returns the last value." However, I don't think this is intuitive. When I first looked at this code, I thought that `request.data[upload_field_name]` would return a list. 

This pull request does not change any of the functionality of this code. However, it makes it explicit that we are receiving metadata from FilePond and ignoring it. I feel this would make the code easier to understand, and it makes it clear how someone could get the metadata if they needed it.