### PR TITLE
Improve offset & length metadata check

### DIFF
--- a/django_drf_filepond/uploaders.py
+++ b/django_drf_filepond/uploaders.py
@@ -256,7 +256,7 @@ class FilepondChunkedFileUploader(FilepondFileUploader):
         ulength = request.META.get('HTTP_UPLOAD_LENGTH', None)
         uname = request.META.get('HTTP_UPLOAD_NAME', None)
 
-        if (not uoffset) or (not ulength) or (uname is None):
+        if (uoffset is None) or (ulength is None) or (uname is None):
             return Response('Chunk upload is missing required metadata',
                             status=status.HTTP_400_BAD_REQUEST)
         if int(ulength) != tuc.total_size:


### PR DESCRIPTION
Background:

One of my colleagues was writing a test of chunked uploads, with some python-based HTTP client, which may have forgotten to turn `HTTP_UPLOAD_OFFSET` into a string. `uoffset` turned out to be an integer with value 0, which is falsy. I think the guard actually meant to check if the value was missing (=> `None`) instead of possibly being zero.