### PR TITLE
replace url

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ DJANGO_DRF_FILEPOND_UPLOAD_TMP = os.path.join(BASE_DIR, 'filepond-temp-uploads')
 Add the URL mappings for django-drf-filepond to your URL configuration in `urls.py`:
 
 ```python
-from django.conf.urls import url, include
+from django.urls import re_path, include
 
 urlpatterns = [
 	...
-	url(r'^fp/', include('django_drf_filepond.urls')),
+	re_path(r'^fp/', include('django_drf_filepond.urls')),
 ]
 ```
 
-On the client side, you need to set the endpoints of the `process`, `revert`, `fetch`, `load`, `restore` and `patch` functions to match the endpoint used in your path statement above. For example if the first parameter to `url` is `fp/` then the endpoint for the process function will be `/fp/process/`.
+On the client side, you need to set the endpoints of the `process`, `revert`, `fetch`, `load`, `restore` and `patch` functions to match the endpoint used in your path statement above. For example if the first parameter to `re_path` is `fp/` then the endpoint for the process function will be `/fp/process/`.
 
 ##### (Optional) 4. File storage configuration
 

--- a/django_drf_filepond/urls.py
+++ b/django_drf_filepond/urls.py
@@ -4,16 +4,16 @@ Based on the server-side configuration details
 provided at:
 https://pqina.nl/filepond/docs/patterns/api/server/#configuration
 """
-from django.conf.urls import url
+from django.urls import path, re_path
 from django_drf_filepond.views import ProcessView, RevertView, LoadView,\
      RestoreView, FetchView, PatchView
 
 urlpatterns = [
-    url(r'^process/$', ProcessView.as_view(), name='process'),
-    url(r'^patch/(?P<chunk_id>[0-9a-zA-Z]{22})$', PatchView.as_view(),
-        name='patch'),
-    url(r'^revert/$', RevertView.as_view(), name='revert'),
-    url(r'^load/$', LoadView.as_view(), name='load'),
-    url(r'^restore/$', RestoreView.as_view(), name='restore'),
-    url(r'^fetch/$', FetchView.as_view(), name='fetch')
+    path('process/', ProcessView.as_view(), name='process'),
+    re_path(r'^patch/(?P<chunk_id>[0-9a-zA-Z]{22})$', PatchView.as_view(),
+            name='patch'),
+    path('revert/', RevertView.as_view(), name='revert'),
+    path('load/', LoadView.as_view(), name='load'),
+    path('restore/', RestoreView.as_view(), name='restore'),
+    path('fetch/', FetchView.as_view(), name='fetch')
 ]

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -14,10 +14,10 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 # from django.contrib import admin
-from django.conf.urls import url, include
+from django.urls import re_path, include
 from django.conf import settings
 
 urlpatterns = [
     # path('admin/', admin.site.urls),
-    url(settings.URL_BASE, include('django_drf_filepond.urls'))
+    re_path(settings.URL_BASE, include('django_drf_filepond.urls'))
 ]


### PR DESCRIPTION
In Django 4.0 `django.conf.urls.url()` is removed. Instead should be used `path()` or `re_path()`. With this change Django 1.11 and older versions will not be supported.

https://docs.djangoproject.com/es/4.0/releases/4.0/#features-removed-in-4-0