### PR TITLE
default_app_config is no longer needed

### DIFF
--- a/django_drf_filepond/__init__.py
+++ b/django_drf_filepond/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'django_drf_filepond.apps.DjangoDrfFilepondConfig'
+


### PR DESCRIPTION
I'm pretty sure this can be removed as [they gave up on this >2 years ago](https://code.djangoproject.com/ticket/31180)