### PR TITLE
Add support for handling uploads with an empty final chunk - fixes #72

### DIFF
--- a/django_drf_filepond/uploaders.py
+++ b/django_drf_filepond/uploaders.py
@@ -240,6 +240,11 @@ class FilepondChunkedFileUploader(FilepondFileUploader):
             fd = BytesIO(file_data)
         elif isinstance(file_data, text_type):
             fd = StringIO(file_data)
+        elif len(file_data) == 0:
+            # This may be a final empty request in relation to a completed
+            # upload - see issue #72 - accept the request
+            return Response(chunk_id, status=status.HTTP_200_OK,
+                            content_type='text/plain')
         else:
             return Response('Upload data type not recognised.',
                             status=status.HTTP_400_BAD_REQUEST)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme:
 
 setup(
     name="django-drf-filepond",
-    version="0.4.1",
+    version="0.5.0",
     description="Filepond server app for Django REST Framework",
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/test_uploaders_chunked.py
+++ b/tests/test_uploaders_chunked.py
@@ -178,6 +178,7 @@ class UploadersFileChunkedTestCase(TestCase):
         self.upload_name = 'my_test_file.png'
         self.uploader = FilepondChunkedFileUploader()
         self.request = MagicMock(spec=Request)
+        self.request.META = {}
         self.request.user = AnonymousUser()
         self.request.data = ensure_text(
             'This is the test upload chunk data...')


### PR DESCRIPTION
As described in #72, an upload that has a size that is an exact multiple of the upload chunk size set on the filepond client configuration results in the upload of an empty final chunk.

Previously this was not handled correctly since as soon as _django-drf-filepond_ detects that the amount of data received for an upload is equal to the data size specified in the upload headers, it goes ahead and processes the uploaded chunks, converting them to the full file and storing this as a `TemporaryUpload` object. The database record created to track the chunks being uploaded is then removed. When the final chunk upload comes in with no data, it doesn't match a `TemporaryUploadChunked` object so the `PATCH` request fails and the upload on the client side then fails too.

This has been addressed by checking if a `PATCH` request has no data. If that's the case, the headers are checked to verify that the request relates to an upload where all data has already been transferred and if that's the case, the request is accepted. The upload then completes successfully on the client side.