### PR TITLE
Add new ChunkedUploadedFile object to resolve memory usage issues when combining file chunks

### DIFF
--- a/django_drf_filepond/drf_filepond_settings.py
+++ b/django_drf_filepond/drf_filepond_settings.py
@@ -69,3 +69,32 @@ ALLOW_EXTERNAL_UPLOAD_DIR = getattr(settings,
                                     False)
 # Optional permissions settings for each endpoint.
 PERMISSION_CLASSES = getattr(settings, _app_prefix+'PERMISSION_CLASSES', {})
+
+# Temporary filepond uploads larger than a certain size are broken up into
+# "chunks" to be sent from the client to the server. This setting DOES NOT
+# control the size of these chunks - they are instead controlled from the
+# client side by specifying the chunkSize property (see filepond server
+# properties: https://pqina.nl/filepond/docs/api/instance/properties/#server)
+#
+# This setting controls the way that chunks are read when django-drf-filepond
+# saves a chunked temporary upload on the server to a complete file. Chunks
+# are stored to individual chunk files on the server that when combined make
+# up the complete file being uploaded. When the upload from the client of all
+# chunks forming a full file is complete, the server combines the chunks into
+# a full file - to do this, it reads in the data from the chunk files in
+# blocks and writes them out to the complete file on disk. This setting
+# controls the size of these blocks, or chunks.
+#
+# For most users the default setting should be fine, however, this ultimately
+# controls how much memory is used (beyond that required for the original
+# data upload) when storing files. In the original implementation, all chunk
+# data was read in at once before writing the file content out to disk as a
+# complete file ending up in usage of memory 2*<size of upload>.
+# The default setting here of 1MB should result in total memory usage for
+# upload handling of <size of upload>+1MB. If you are working with very
+# large uploads, this may be inefficient and you may want to increase the
+# setting, at the expense of temporarily using more memory, to improve
+# efficiency.
+TEMPFILE_READ_CHUNK_SIZE = getattr(settings,
+                                   _app_prefix+'TEMPFILE_READ_CHUNK_SIZE',
+                                   1048576)

--- a/django_drf_filepond/exceptions.py
+++ b/django_drf_filepond/exceptions.py
@@ -10,3 +10,10 @@ class APIError(Exception):
     Raised when a problem occurs in the API functions.
     '''
     pass
+
+
+class ChunkedUploadError(Exception):
+    '''
+    Raised when an error occurs processing a chunked upload.
+    '''
+    pass

--- a/django_drf_filepond/models.py
+++ b/django_drf_filepond/models.py
@@ -180,9 +180,11 @@ def delete_temp_upload_file(sender, instance, **kwargs):
                 os.path.isfile(instance.file.path)):
             os.remove(instance.file.path)
 
+    LOG.debug('*** post_delete <%s> - Value of DELETE_UPLOAD_TMP_DIRS: %s'
+              % (instance.upload_id, str(local_settings.DELETE_UPLOAD_TMP_DIRS)))
     if local_settings.DELETE_UPLOAD_TMP_DIRS:
         file_dir = os.path.join(storage.location, instance.upload_id)
-        if(os.path.exists(file_dir) and os.path.isdir(file_dir)):
+        if (os.path.exists(file_dir) and os.path.isdir(file_dir)):
             os.rmdir(file_dir)
             LOG.debug('*** post_delete signal handler called. Deleting temp '
                       'dir that contained file.')

--- a/django_drf_filepond/parsers.py
+++ b/django_drf_filepond/parsers.py
@@ -32,7 +32,7 @@ class PlainTextParser(BaseParser):
 # upload support. A chunk upload request has a content type of
 # application/offset+octet-stream. For now we simply get the raw request data
 # and return it.
-# TODO: This could alse extract metadata from the request, such as chunk
+# TODO: This could also extract metadata from the request, such as chunk
 #       length, name and offset and return an object containing the data and
 #       the metadata. For now the metadata is extracted and checked prior to
 #       accessing the uploaded data.

--- a/django_drf_filepond/uploaders.py
+++ b/django_drf_filepond/uploaders.py
@@ -174,6 +174,9 @@ class FilepondChunkedFileUploader(FilepondFileUploader):
                 return Response('Invalid ID for handling upload.',
                                 status=status.HTTP_500_INTERNAL_SERVER_ERROR)
             return self._handle_new_chunk_upload(request, upload_id, file_id)
+        else:
+            return Response('Invalid method.',
+                            status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def _handle_new_chunk_upload(self, request, upload_id, file_id):
         LOG.debug('Processing a new chunked upload request...')

--- a/django_drf_filepond/utils.py
+++ b/django_drf_filepond/utils.py
@@ -1,8 +1,15 @@
 # A module containing some utility functions used by the views and uploaders
-import django_drf_filepond.drf_filepond_settings as local_settings
-from django.contrib.auth.models import AnonymousUser
+from io import UnsupportedOperation
+import os
+
 import shortuuid
 import six
+from django.contrib.auth.models import AnonymousUser
+from django.core.files.uploadedfile import UploadedFile
+from django.utils.functional import cached_property
+
+import django_drf_filepond.drf_filepond_settings as local_settings
+from django_drf_filepond.models import storage
 
 
 # Get the user associated with the provided request. If we have an anonymous
@@ -43,3 +50,139 @@ def _process_base_dir(base_dir):
     if isinstance(base_dir, Path):
         return str(base_dir)
     return base_dir
+
+
+# A custom "django.core.files.uploadedfile.UploadedFile" object that picks
+# up the chunked files stored separately on disk for a chunked upload.
+# At present, these are "reconstituted" into a BytesIO object and then
+# passed to an InMemoryUploadedFile object, however, this results in using
+# double the memory of the size of the stored upload which has been causing
+# issues for users handling large uploads (see issue #64 - https://github.com
+# /ImperialCollegeLondon/django-drf-filepond/issues/64). This uploadded
+# file obejct addresses this issue by loading the required chunk data in
+# on demand.
+# To be able to process the chunks we need the chunk directory, the file_id
+# (the filename prefix used for all chunk files), and the number of chunks.
+# All this data is obtained from the instance of the TemporaryUploadChunked
+# object provided.
+class DrfFilepondChunkedUploadedFile(UploadedFile):
+    def __init__(self, temp_chunked_upload_model_obj, content_type=None):
+        # From superclass __init__
+        # file=None, name=None, content_type=None, size=None, charset=None,
+        # content_type_extra=None
+        super().__init__(None, temp_chunked_upload_model_obj.upload_name)
+        # Remove the size attribute so that it is recalulated by the property
+        # function.
+        delattr(self, 'size')
+        self.content_type = content_type
+        self.charset = None
+        self.content_type_extra = None
+        self.chunk_dir = os.path.join(
+            storage.base_location,
+            temp_chunked_upload_model_obj.upload_dir)
+        self.chunk_base = temp_chunked_upload_model_obj.file_id
+        self.num_chunks = temp_chunked_upload_model_obj.last_chunk
+        self.total_size = temp_chunked_upload_model_obj.total_size
+        self.first_file = os.path.join(
+            self.chunk_dir, '%s_1' % (self.chunk_base))
+        if not os.path.exists(self.first_file):
+            raise FileNotFoundError('Initial chunk for this file not found.')
+        self.chunk_size = os.path.getsize(self.first_file)
+
+        self.offset = 0
+        # 1-indexed value for current chunk (chunks start at 1)
+        self.current_chunk = 1
+
+    # Override the parent File class's size property and calculate
+    # this based on the all the chunk files.
+    @cached_property
+    def size(self):
+        if os.path.exists(self.chunk_dir):
+            size = 0
+            try:
+                for i in range(self.num_chunks):
+                    size += os.path.getsize(os.path.join(
+                        self.chunk_dir, '%s_%s' % (self.chunk_base, (i+1))))
+            except OSError as e:
+                raise AttributeError(
+                    'Unable to get the file\'s size: %s' % str(e))
+            return size
+        raise AttributeError('Unable to determine the file\'s size.')
+
+    def chunks(self, chunk_size=None):
+        """
+        The file is being read as a series of ``chunk files``. These may
+        differ in size to self.chunk_size.
+
+        Read ``chunk_size`` bytes from the current file and yield. If the read
+        goes over the end of the current chunk and into the next one, close
+        the current file, open the next and continue reading up to chunk_size.
+        """
+        if self.closed:
+            raise OSError('File must be opened with "open(mode)" before '
+                          'attempting to read data')
+        chunk_size = chunk_size or self.DEFAULT_CHUNK_SIZE
+
+        # Reset ourselves back to the start of the first chunk.
+        if self.current_chunk == 1:
+            try:
+                self.seek(0)
+                self.offset = 0
+            except (AttributeError, UnsupportedOperation):
+                pass
+        else:
+            self.current_chunk = 1
+            self.offset = 0
+            self.file = open(self.first_file, self.mode)
+
+        while self.offset < self.total_size:
+            print('Current offset: %s' % self.offset)
+            chunk_bytes_read = 0
+            data = self.read(chunk_size)
+            bytes_read = len(data)
+            chunk_bytes_read += bytes_read
+            self.offset += bytes_read
+            print('Offset after initial chunk read: %s' % self.offset)
+            while chunk_bytes_read < chunk_size:
+                # Open the next file and continue reading
+                self.file.close()
+                self.current_chunk += 1
+                # If we've passed the end of all chunks, break from loop
+                if self.current_chunk > self.num_chunks:
+                    break
+                # Otherwise open the next file and continue reading
+                else:
+                    self.file = open(os.path.join(
+                        self.chunk_dir,
+                        '%s_%s' % ((self.chunk_base, self.current_chunk))
+                    ), self.file.mode)
+                new_data = self.read(chunk_size - chunk_bytes_read)
+                bytes_read = len(new_data)
+                chunk_bytes_read += bytes_read
+                self.offset += bytes_read
+                data += new_data
+                print('Offset after subsequent chunk read: %s' % self.offset)
+
+            if (not data):
+                print('No more data, leaving loop at offset: %s' % self.offset)
+                break
+
+            print('Yielding data...')
+            yield data
+
+    def multiple_chunks(self, chunk_size=None):
+        return True
+
+    def open(self, mode):
+        self.mode = mode
+
+        if self.first_file and os.path.exists(self.first_file):
+            if not self.closed:
+                self.close()
+
+            self.current_chunk = 1
+            self.offset = 0
+            self.file = open(self.first_file, self.mode)
+        else:
+            raise ValueError("The file cannot be reopened.")
+        return self

--- a/django_drf_filepond/utils.py
+++ b/django_drf_filepond/utils.py
@@ -134,8 +134,15 @@ class DrfFilepondChunkedUploadedFile(UploadedFile):
                 self.seek(0)
                 self.offset = 0
             except (AttributeError, UnsupportedOperation):
-                pass
+                # This except block is the same as the one in the top-level
+                # django.core.files.base.File obejct to maintain compatibility
+                # with the top-level object, adding a debug statement instead
+                # of "pass" as in top-level to provide some feedback.
+                LOG.debug('AttributeError or UnsupportedOperation when '
+                          'trying to seek to 0')
         else:
+            # Close current file and reset data then open first file
+            self.close()
             self.current_chunk = 1
             self.offset = 0
             self.file = open(self.first_file, self.mode)

--- a/django_drf_filepond/utils.py
+++ b/django_drf_filepond/utils.py
@@ -32,6 +32,13 @@ def _get_file_id():
     return six.ensure_text(file_id)
 
 
+# There's no built in FileNotFoundError in Python 2
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
+
 # Get the BASE_DIR variable from local_settings and process it to ensure that
 # it can be used in django_drf_filepond across Python 2.7, 3.5 and 3.6+.
 # Need to take into account that this may be a regular string or a

--- a/django_drf_filepond/utils.py
+++ b/django_drf_filepond/utils.py
@@ -181,16 +181,24 @@ class DrfFilepondChunkedUploadedFile(UploadedFile):
     def multiple_chunks(self, chunk_size=None):
         return True
 
+    # TODO: Add seek support - ensure we can seek to any offset
+    # through the different chunks.
+
     def open(self, mode):
         self.mode = mode
 
         if self.first_file and os.path.exists(self.first_file):
             if not self.closed:
+                # calls close on self.file which may not be the first file
+                # Once seek is implemented, this should call seek(0).
                 self.close()
 
+            # Now set the chunk back to 1 and offset to 0 and open
+            # the file for the first chunk.
             self.current_chunk = 1
             self.offset = 0
             self.file = open(self.first_file, self.mode)
         else:
+            # Retain the same ValueError/message as top-level superclass
             raise ValueError("The file cannot be reopened.")
         return self

--- a/tests/test_chunked_uploaded_file.py
+++ b/tests/test_chunked_uploaded_file.py
@@ -1,0 +1,150 @@
+#############################################################################
+#                                                                           #
+#  Tests for DrfFilepondChunkedUploadedFile. These tests check the handling #
+#  of chunked file uploads using the chunked uploaded file class which      #
+#  provides a file interface over a set of file chunks stored on disk.      #
+#                                                                           #
+#############################################################################
+from django_drf_filepond.utils import DrfFilepondChunkedUploadedFile
+from django_drf_filepond.models import TemporaryUploadChunked
+import logging
+
+from django.test.testcases import TestCase
+
+# Python 2/3 support
+try:
+    from unittest.mock import MagicMock, Mock, patch, call
+except ImportError:
+    from mock import MagicMock, Mock, patch, call
+
+LOG = logging.getLogger(__name__)
+
+
+#############################################################################
+# Test the various capabilities and error conditions of the
+# DrfFilepondChunkedUploadedFile class.
+#
+# test_chunked_upload_first_file_missing: We expect a FileNotFoundError if
+#     we try to create a DrfFilepondChunkedUploadedFile instance when the
+#     first chunk file is not present.
+#
+# test_chunked_upload_read_without_open: We expect an OSError if we try to
+#     read from a DrfFilepondChunkedUploadedFile without calling open(mode)
+#
+# test_file_size_no_file: Check that we get an AttributeError if the
+#     directory for the chunk files is missing.
+#
+# test_file_size_not_accessible: Check that we get an attribute error if
+#     the getsize call fails on one of the file chunks.
+#
+# test_file_size_valid_files: Check that we can correctly calculate the
+#     size of a set of (mocked) file chunks.
+#
+#############################################################################
+class ChunkedUploadedFileTestCase(TestCase):
+
+    def setUp(self):
+        tuc = TemporaryUploadChunked()
+        tuc.upload_id = 'EpqiJa5KFg8mbXryAPFVbC'
+        tuc.file_id = 'MifCFREScUJH8ybrYwduoB'
+        tuc.last_chunk = 13
+        tuc.upload_dir = 'EpqiJa5KFg8mbXryAPFVbC'
+        tuc.upload_complete = True
+        tuc.upload_name = 'test_data.dat'
+        tuc.total_size = 1048576
+        self.tuc = tuc
+
+        self.test_file_loc = '/test/location'
+
+    def _setup_mocks(self, exists_val=False):
+        # Mock out the "os" calls made when creating instance of chunked obj
+        os = MagicMock()
+        os.path = MagicMock()
+        # Mocking the return of self.chunk_dir which is the join of
+        # (storage.base_location (self.test_file_loc), tuc.upload_dir)
+        # and self.first_file which is (self.chunk_dir, self.chunk_base + _1)
+        # where self.chunk_base is tuc.file_id
+        chunk_dir = self.test_file_loc + '/' + self.tuc.upload_dir
+        first_file = chunk_dir + '/' + self.tuc.file_id + '_1'
+        os.path.join = Mock(side_effect=[chunk_dir, first_file])
+        if type(exists_val) == list:
+            os.path.exists = Mock(side_effect=exists_val)
+        else:
+            os.path.exists = Mock(return_value=exists_val)
+        os.path.getsize = Mock(return_value=65536)
+        storage = MagicMock()
+        storage.base_location = self.test_file_loc
+        return(os, storage, chunk_dir, first_file)
+
+    def test_chunked_upload_first_file_missing(self):
+        '''We expect a FileNotFoundError if we try to create a
+           DrfFilepondChunkedUploadedFile instance when the first chunk
+           file is not present.'''
+        mock_os, mock_storage, chunk_dir, _ = self._setup_mocks()
+        with patch('django_drf_filepond.utils.os', mock_os):
+            with patch('django_drf_filepond.utils.storage', mock_storage):
+                with self.assertRaisesRegex(
+                        FileNotFoundError,
+                        'Initial chunk for this file not found.'):
+                    DrfFilepondChunkedUploadedFile(
+                        self.tuc, 'application/octet-stream')
+        # Check the expected path was created/used when getting file location
+        mock_os.path.join.assert_has_calls(
+            [call(self.test_file_loc, self.tuc.upload_dir),
+             call(chunk_dir, self.tuc.file_id + '_1')])
+        mock_os.path.exists.assert_called_once_with(
+            '%s/%s_1' % (chunk_dir, self.tuc.file_id))
+
+    def test_chunked_upload_read_without_open(self):
+        '''We expect an OSError if we try to read from a
+           DrfFilepondChunkedUploadedFile without calling open(mode)'''
+        mock_os, mock_storage, chunk_dir, _ = self._setup_mocks(True)
+        with patch('django_drf_filepond.utils.os', mock_os):
+            with patch('django_drf_filepond.utils.storage', mock_storage):
+                with self.assertRaisesRegex(
+                    OSError, ('File must be opened with "open\(mode\)" before '
+                              'attempting to read data')):
+                    f = DrfFilepondChunkedUploadedFile(
+                        self.tuc, 'application/octet-stream')
+                    for chunk in f.chunks():
+                        pass
+        # # Check the expected path was created/used when getting file location
+        # mock_os.path.join.assert_has_calls(
+        #     [call(self.test_file_loc, self.tuc.upload_dir),
+        #      call(chunk_dir, self.tuc.file_id + '_1')])
+        # mock_os.path.exists.assert_called_once_with(
+        #     '%s/%s_1' % (chunk_dir, self.tuc.file_id))
+
+    def test_file_size_no_file(self):
+        '''Check that we get an AttributeError if the directory
+           for the chunk files is missing.'''
+        mock_os, mock_storage, chunk_dir, first_file = self._setup_mocks(
+            [True, False])
+        with patch('django_drf_filepond.utils.os', mock_os):
+            with patch('django_drf_filepond.utils.storage', mock_storage):
+                f = DrfFilepondChunkedUploadedFile(
+                    self.tuc, 'application/octet-stream')
+                with self.assertRaises(
+                        AttributeError,
+                        msg='Unable to determine the file\'s size.'):
+                    f.size
+
+    def test_file_size_not_accessible(self):
+        '''Check that we get an attribute error if the getsize call
+           fails on one of the file chunks.'''
+        mock_os, mock_storage, chunk_dir, first_file = self._setup_mocks(True)
+        mock_os.path.getsize = Mock(
+            side_effect=[65536, OSError('Testing error getting size.')])
+        with patch('django_drf_filepond.utils.os', mock_os):
+            with patch('django_drf_filepond.utils.storage', mock_storage):
+                f = DrfFilepondChunkedUploadedFile(
+                    self.tuc, 'application/octet-stream')
+                with self.assertRaisesRegex(
+                    AttributeError, ('Unable to determine the file\'s size'
+                                     ': Testing error getting size.')):
+                    f.size
+
+    def test_file_size_valid_files(self):
+        '''Check that we can correctly calculate the size of a set of
+           (mocked) file chunks.'''
+        pass

--- a/tests/test_chunked_uploaded_file.py
+++ b/tests/test_chunked_uploaded_file.py
@@ -5,21 +5,23 @@
 #  provides a file interface over a set of file chunks stored on disk.      #
 #                                                                           #
 #############################################################################
+from django_drf_filepond.exceptions import ChunkedUploadError
 import logging
+import os
 import random
 import string
-from io import UnsupportedOperation
+from io import BytesIO, UnsupportedOperation
 
 import django_drf_filepond.drf_filepond_settings as local_settings
 from django.test.testcases import TestCase
 from django_drf_filepond.models import TemporaryUploadChunked
 from django_drf_filepond.utils import DrfFilepondChunkedUploadedFile
 
-# Python 2/3 support
-try:
-    from unittest.mock import MagicMock, Mock, call, mock_open, patch
-except ImportError:
-    from mock import MagicMock, Mock, call, mock_open, patch
+# Tests in this module require a version of mock that provides mock_open
+# with support for a size parameter on it's returned readable object.
+# We therefore use only the third party mock module (in place of unittest.
+# mock) here since this is defined as a dependency in setup.py anyway.
+from mock import MagicMock, Mock, call, mock_open, patch
 
 LOG = logging.getLogger(__name__)
 
@@ -68,6 +70,11 @@ LOG = logging.getLogger(__name__)
 # test_chunks_specified_size_used: Check that when a chunk size is specified
 #     on call to chunks(), that that this is used.
 #
+# test_chunks_read_chunk_larger_than_file: Check that when a chunk size is
+#     specified on call to chunks() that is larger than the specified file
+#     chunk size, that that this is handled successfully and used. This will
+#     require reading from more than one file for each chunk yielded.
+#
 # test_chunks_seek0_when_on_chunk_1: Check that when the current chunk is
 #     chunk 1 the read seeks to 0 and resets the offset.
 #
@@ -82,8 +89,10 @@ LOG = logging.getLogger(__name__)
 # test_chunks_read_full_data_less_than_chunk_size: Read some data that has
 #     a total size of less than chunk size.
 #
-# test_chunks_read_full_data_multiple_chunks: Test reading of a set of
-#     multiple chunk "files" that are sized differently to the chunk size.
+# test_chunks_read_full_data_same_chunk_size_incomplete_final: Test reading
+#    of a set of multiple chunk "files" that are each the same size as the
+#    chunk size, except for the final chunk which is less than the chunk
+#    size - i.e. our test file is not an exact multiple of the chunk size.
 #
 # test_chunks_read_full_data_exact_chunk_multiple: Test reading of a set of
 #     multiple chunk "files" that are each the same size as the chunk size.
@@ -91,7 +100,22 @@ LOG = logging.getLogger(__name__)
 # test_chunks_read_full_data_crossing_chunks: Test reading of a set of
 #     multiple chunk "files" that are sized differently to the chunk size,
 #     using a read chunk size that ensures we cross chunk file boundaries
-#     during some reads.
+#     during some reads. Check resulting read for equality with original
+#     bytes.
+#
+# test_chunks_exact_chunk_multiple_empty_chunk: Due to the way that the
+#     filepond client handles uploads, if the upload is an exact multiple
+#     of the chunk size being used for uploads on the client side, the
+#     final chunk will be empty. Test that this is handled correctly.
+#
+# test_chunks_not_enough_data_error: Check that when we have a set of chunk
+#     files that don't contain enough data for the specified total file
+#     size that a ChunkedUploadError is raised.
+#
+# test_chunks_not_enough_data_error_empty_files: Check that when we
+#     have a set of chunks that don't contain enough data for the
+#     specified total file size and that some of these files are empty,
+#     a ChunkedUploadError is raised.
 #
 #############################################################################
 class ChunkedUploadedFileTestCase(TestCase):
@@ -109,7 +133,7 @@ class ChunkedUploadedFileTestCase(TestCase):
 
         self.test_file_loc = '/test/location'
 
-    def _setup_mocks(self, exists_val=False):
+    def _setup_mocks(self, exists_val=False, join_list=None):
         # Mock out the "os" calls made when creating instance of chunked obj
         os = MagicMock()
         os.path = MagicMock()
@@ -119,7 +143,10 @@ class ChunkedUploadedFileTestCase(TestCase):
         # where self.chunk_base is tuc.file_id
         chunk_dir = self.test_file_loc + '/' + self.tuc.upload_dir
         self.first_file = chunk_dir + '/' + self.tuc.file_id + '_1'
-        os.path.join = Mock(side_effect=[chunk_dir] + [self.first_file]*5)
+        if not join_list:
+            os.path.join = Mock(side_effect=[chunk_dir] + [self.first_file]*5)
+        else:
+            os.path.join = Mock(side_effect=join_list)
         if type(exists_val) == list:
             os.path.exists = Mock(side_effect=exists_val)
         else:
@@ -134,23 +161,26 @@ class ChunkedUploadedFileTestCase(TestCase):
         default_data = (
             'ERROR: Got default data - expected filename not requested')
         mock_data = {}
+        full_data = b''
 
         for key in mock_data_info:
             file_size = mock_data_info[key]
-            # file_data_01 = BytesIO(os.urandom(file_size))
-            file_data = ''.join(
-                random.choices(string.ascii_lowercase +
-                               string.ascii_uppercase +
-                               string.punctuation,
-                               k=file_size))
+            file_data = os.urandom(file_size)
+            full_data += file_data
+            # file_data = ''.join(
+            #     random.choices(string.ascii_lowercase +
+            #                    string.ascii_uppercase +
+            #                    string.punctuation,
+            #                    k=file_size))
             mock_data[key] = file_data
 
         def mock_open_se(fname, mode=None):
             mo = mock_open(read_data=mock_data.get(fname, default_data))()
             mo.closed = False
+            mo.mode = 'rb'
             return mo
 
-        return mock_open_se
+        return (mock_open_se, full_data)
 
     def test_chunked_upload_first_file_missing(self):
         '''We expect a FileNotFoundError if we try to create a
@@ -331,12 +361,62 @@ class ChunkedUploadedFileTestCase(TestCase):
     def test_chunks_default_chunk_size(self):
         '''Check that when no chunk size is specified on call to chunks(),
            that the default chunk size from settings is used.'''
-        raise NotImplementedError('This test is not yet implemented.')
+        default_chunk_size = local_settings.TEMPFILE_READ_CHUNK_SIZE
+        self._run_chunk_size_test(
+            8388608, default_chunk_size, default_chunk_size)
 
     def test_chunks_specified_size_used(self):
         '''Check that when a chunk size is specified on call to chunks(),
            that that this is used.'''
-        raise NotImplementedError('This test is not yet implemented.')
+        default_chunk_size = local_settings.TEMPFILE_READ_CHUNK_SIZE
+        total_size = 8388608
+        file_size = default_chunk_size
+        read_chunk_size = 8192
+
+        if (total_size % file_size) != 0:
+            raise ValueError('The default chunk size must be a multiple of '
+                             'the total size for the purpose of these tests.')
+        num_chunks = total_size // file_size
+        self.tuc.total_size = (file_size * num_chunks)
+        self.tuc.last_chunk = num_chunks
+
+        chunk_dir = self.test_file_loc + '/' + self.tuc.upload_dir
+        chunk_file_base = chunk_dir + '/' + self.tuc.file_id + '_'
+
+        join_list = [chunk_dir] + [
+            chunk_file_base+str(i) for i in range(1, self.tuc.last_chunk + 1)]
+
+        mock_data_info = {}
+        for i in range(1, num_chunks + 1):
+            mock_data_info[chunk_file_base + str(i)] = file_size
+
+        (mock_open_se, _) = self._init_file_tests(mock_data_info)
+
+        mock_os, mock_storage, _, _ = self._setup_mocks(
+            True, join_list=join_list)
+
+        with patch('django_drf_filepond.utils.os', mock_os):
+            with patch('django_drf_filepond.utils.storage', mock_storage):
+                with patch('builtins.open', side_effect=mock_open_se):
+                    f = DrfFilepondChunkedUploadedFile(
+                        self.tuc, 'application/octet-stream')
+                    self.assertEqual(f.first_file, self.first_file)
+                    f.open('rb')
+                    data = b''
+                    i = 1
+                    for c in f.chunks(chunk_size=read_chunk_size):
+                        # Confirm that we read the expected default chunk size
+                        self.assertEqual(read_chunk_size, len(c))
+                        data += c
+                        i += 1
+                    f.close()
+
+    def test_chunks_read_chunk_larger_than_file(self):
+        '''Check that when a chunk size is specified on call to chunks() that
+           is larger than the specified file chunk size, that that this is
+           handled successfully and used. This will require reading from more
+           than one file for each chunk yielded.'''
+        self._run_chunk_size_test(8388608, 1048576, 2097152)
 
     def test_chunks_seek0_when_on_chunk_1(self):
         '''Check that when the current chunk is chunk 1 the read seeks to
@@ -426,7 +506,7 @@ class ChunkedUploadedFileTestCase(TestCase):
 
         mock_os, mock_storage, chunk_dir, first_file = self._setup_mocks(True)
         mock_data_info = {first_file: file_size}
-        mock_open_se = self._init_file_tests(mock_data_info)
+        (mock_open_se, _) = self._init_file_tests(mock_data_info)
 
         with patch('django_drf_filepond.utils.os', mock_os):
             with patch('django_drf_filepond.utils.storage', mock_storage):
@@ -435,7 +515,7 @@ class ChunkedUploadedFileTestCase(TestCase):
                         self.tuc, 'application/octet-stream')
                     self.assertEqual(f.first_file, self.first_file)
                     f.open('rb')
-                    data = ''
+                    data = b''
                     for c in f.chunks():
                         data += c
                     f.close()
@@ -444,24 +524,201 @@ class ChunkedUploadedFileTestCase(TestCase):
         self.assertEqual(f.offset, file_size)
         mo.assert_called_once_with(self.first_file, 'rb')
 
-    def test_chunks_read_full_data_multiple_chunks(self):
-        '''Test reading of a set of multiple chunk "files" that are sized
-           differently to the chunk size.'''
-        default_chunk_size = local_settings.TEMPFILE_READ_CHUNK_SIZE
-        chunk_file_size = default_chunk_size // 2
+    def test_chunks_read_full_data_same_chunk_size_incomplete_final(self):
+        '''Test reading of a set of multiple chunk "files" that are each the
+           same size as the chunk size, except for the final chunk which is
+           less than the chunk size - i.e. our test file is not an exact
+           multiple of the chunk size.'''
+        chunk_file_size = local_settings.TEMPFILE_READ_CHUNK_SIZE
         last_file_size = chunk_file_size - 345
         self.tuc.total_size = (chunk_file_size * 8) + last_file_size
         self.tuc.last_chunk = 9
 
-        mock_os, mock_storage, chunk_dir, first_file = self._setup_mocks(True)
-        # Remove chunk number from first file
-        chunk_file_base = first_file[:-1]
-        mock_data_info = {}
-        for i in range(1, 10):
-            mock_data_info[chunk_file_base + str(i)] = (
-                chunk_file_size if i != 9 else last_file_size)
+        chunk_dir = self.test_file_loc + '/' + self.tuc.upload_dir
+        first_file = chunk_dir + '/' + self.tuc.file_id + '_1'
 
-        mock_open_se = self._init_file_tests(mock_data_info)
+        join_list = [chunk_dir] + [
+            first_file[:-1]+str(i) for i in range(1, self.tuc.last_chunk + 1)]
+
+        (f, mo, _, _, _) = self._run_chunked_file_test(
+            join_list, chunk_file_size, self.tuc.last_chunk, last_file_size)
+
+        # Current chunk should be last chunk + 1 since we have a final file
+        # that is sized such that it doesn't end exactly on a chunk boundary
+        self.assertEqual(f.current_chunk, 10)
+        self.assertEqual(f.offset, (chunk_file_size * 8) + last_file_size)
+        mo.assert_has_calls([
+            call(file_item, 'rb') for file_item in join_list[1:]])
+
+    def test_chunks_read_full_data_exact_chunk_multiple(self):
+        '''Test reading of a set of multiple chunk "files" that are each the
+           same size as the chunk size.'''
+        chunk_file_size = local_settings.TEMPFILE_READ_CHUNK_SIZE
+        last_file_size = chunk_file_size
+        self.tuc.total_size = (chunk_file_size * 11)
+        self.tuc.last_chunk = 11
+
+        chunk_dir = self.test_file_loc + '/' + self.tuc.upload_dir
+        first_file = chunk_dir + '/' + self.tuc.file_id + '_1'
+
+        join_list = [chunk_dir] + [
+            first_file[:-1]+str(i) for i in range(1, self.tuc.last_chunk + 1)]
+
+        (f, mo, _, _, _) = self._run_chunked_file_test(
+            join_list, chunk_file_size, self.tuc.last_chunk, last_file_size)
+
+        # When the final chunk is smaller than the chunk size, current chunk
+        # should be last chunk + 1 because the loop sees that it hasn't read
+        # the full chunk size and increments the current chunk to see if
+        # there's a file available with more data in the next chunk. When the
+        # file is an exact multiple of the chunk size, we never enter the loop
+        # to get more data after reading the final complete chunk so
+        # current_chunk should equal the total number of chunks.
+        self.assertEqual(f.current_chunk, 11)
+        self.assertEqual(f.offset, (chunk_file_size * 11))
+        mo.assert_has_calls([
+            call(file_item, 'rb') for file_item in join_list[1:]])
+
+    def test_chunks_read_full_data_crossing_chunks(self):
+        '''Test reading of a set of multiple chunk "files" that are sized
+           differently to the chunk size, using a read chunk size that
+           ensures we cross chunk file boundaries during some reads.
+           Check resulting read for equality with original bytes.'''
+        total_size = 234489
+        file_size = 65536
+        read_chunk_size = 2359
+
+        last_file_size = total_size % file_size
+        num_chunks = (total_size // file_size) + 1
+        self.tuc.total_size = total_size
+        self.tuc.last_chunk = num_chunks
+
+        chunk_dir = self.test_file_loc + '/' + self.tuc.upload_dir
+        chunk_file_base = chunk_dir + '/' + self.tuc.file_id + '_'
+
+        join_list = [chunk_dir] + [
+            chunk_file_base+str(i) for i in range(1, self.tuc.last_chunk + 1)]
+
+        (f, mo, iterations, data, full_data) = self._run_chunked_file_test(
+            join_list, file_size, num_chunks, last_file_size, read_chunk_size)
+
+        # Current chunk should be last chunk + 1
+        self.assertEqual(f.current_chunk, num_chunks+1)
+        self.assertEqual(f.offset, total_size)
+        mo.assert_has_calls([
+            call(file_item, 'rb') for file_item in join_list[1:]])
+        # Check that the number of read iterations is based on the
+        # read_chunk_size and that the data read matches the original
+        self.assertEqual(iterations, 100)
+        arrays_equal = True
+        b1 = BytesIO(data)
+        b2 = BytesIO(full_data)
+        for i in range(total_size):
+            byte1 = b1.read(1)
+            byte2 = b2.read(1)
+            if byte1 != byte2:
+                arrays_equal = False
+        self.assertTrue(arrays_equal,
+                        'Original byte array data is not equal to data read.')
+
+    def test_chunks_exact_chunk_multiple_empty_chunk(self):
+        '''Due to the way that the filepond client handles uploads, if the
+           upload is an exact multiple of the chunk size being used for
+           uploads on the client side, the final chunk will be empty. Test
+           that this is handled correctly.'''
+        
+        # In reality, this situation shouldn't, in fact, occur. While the
+        # filepond client does send an empty PATCH request at the end of
+        # a set of chunks when the upload is an exact multiple of the
+        # upload chunk size set in the configuration for the frontend client,
+        # once django-drf-filepond detects that all bytes for a file have been
+        # recieved, it assembles the chunks into the complete file.
+        # The server code has been updated to accept the empty request when
+        # this follows a completed temporary upload but an empty chunk file at
+        # the end of the set of chunks is never actually stored.
+        # Nonetheless, we check here that this case can still be handled.
+        chunk_file_size = local_settings.TEMPFILE_READ_CHUNK_SIZE
+        last_file_size = 0
+        self.tuc.total_size = (chunk_file_size * 4)
+        self.tuc.last_chunk = 5
+
+        chunk_dir = self.test_file_loc + '/' + self.tuc.upload_dir
+        chunk_file_base = chunk_dir + '/' + self.tuc.file_id + '_'
+
+        join_list = [chunk_dir] + [
+            chunk_file_base+str(i) for i in range(1, self.tuc.last_chunk + 1)]
+
+        (f, mo, iterations, data, full_data) = self._run_chunked_file_test(
+            join_list, chunk_file_size, self.tuc.last_chunk, last_file_size)
+
+        # Current chunk should be equal to the last chunk since the
+        # file read is complete on the boundary of a chunk file.
+        self.assertEqual(f.current_chunk, self.tuc.last_chunk - 1)
+        self.assertEqual(f.offset, self.tuc.total_size)
+        mo.assert_has_calls([
+            call(file_item, 'rb') for file_item in join_list[1:-1]])
+        # Check that the number of read iterations is based on the
+        # read_chunk_size and that the data read matches the original
+        self.assertEqual(iterations, self.tuc.total_size // chunk_file_size)
+        arrays_equal = True
+        b1 = BytesIO(data)
+        b2 = BytesIO(full_data)
+        for i in range(self.tuc.total_size):
+            byte1 = b1.read(1)
+            byte2 = b2.read(1)
+            if byte1 != byte2:
+                arrays_equal = False
+        self.assertTrue(arrays_equal,
+                        'Original byte array data is not equal to data read.')
+
+    def test_chunks_not_enough_data_error(self):
+        '''Check that when we have a set of chunk files that don't contain
+           enough data for the specified total file size that a
+           ChunkedUploadError is raised.'''
+        chunk_file_size = 1048576
+        last_file_size = 65536
+        self.tuc.total_size = (chunk_file_size * 4)
+        self.tuc.last_chunk = 4
+
+        chunk_dir = self.test_file_loc + '/' + self.tuc.upload_dir
+        chunk_file_base = chunk_dir + '/' + self.tuc.file_id + '_'
+
+        join_list = [chunk_dir] + [
+            chunk_file_base+str(i) for i in range(1, self.tuc.last_chunk + 1)]
+
+        with self.assertRaisesRegex(
+                ChunkedUploadError,
+                ('No more data, read all chunks but expected file size <%s> '
+                 'not reached - leaving loop at offset: %s'
+                 % (self.tuc.total_size, str(65536*4)))):
+            self._run_chunked_file_test(
+                join_list, 65536, self.tuc.last_chunk, last_file_size)
+
+    def test_chunks_not_enough_data_error_empty_files(self):
+        '''Check that when we have a set of chunks that don't contain enough
+           data for the specified total file size and that some of these
+           files are empty, a ChunkedUploadError is raised.'''
+        chunk_file_size = 1048576
+        self.tuc.total_size = (chunk_file_size * 4)
+        self.tuc.last_chunk = 8
+
+        chunk_dir = self.test_file_loc + '/' + self.tuc.upload_dir
+        chunk_file_base = chunk_dir + '/' + self.tuc.file_id + '_'
+
+        join_list = [chunk_dir] + [
+            chunk_file_base+str(i) for i in range(1, self.tuc.last_chunk + 1)]
+
+        mock_os, mock_storage, chunk_dir, first_file = self._setup_mocks(
+            True, join_list=join_list)
+
+        mock_data_info = {}
+        mock_data_info[chunk_file_base + '1'] = chunk_file_size
+        mock_data_info[chunk_file_base + '2'] = chunk_file_size
+        mock_data_info[chunk_file_base + '8'] = chunk_file_size
+        for i in range(3, 8):
+            mock_data_info[chunk_file_base + str(i)] = 0
+
+        (mock_open_se, full_data) = self._init_file_tests(mock_data_info)
 
         with patch('django_drf_filepond.utils.os', mock_os):
             with patch('django_drf_filepond.utils.storage', mock_storage):
@@ -470,22 +727,99 @@ class ChunkedUploadedFileTestCase(TestCase):
                         self.tuc, 'application/octet-stream')
                     self.assertEqual(f.first_file, self.first_file)
                     f.open('rb')
-                    data = ''
-                    for c in f.chunks():
+                    data = b''
+                    with self.assertRaisesRegex(
+                            ChunkedUploadError,
+                            ('No more data, read all chunks but expected '
+                             'file size <%s> not reached - leaving loop at '
+                             'offset: %s' % (self.tuc.total_size,
+                                             str(chunk_file_size*3)))):
+                        try:
+                            for c in f.chunks():
+                                data += c
+                        finally:
+                            f.close()
+
+    def _run_chunk_size_test(self, total_size, file_size, read_chunk_size):
+        # Check that the file chunk size is a multiple of the total
+        # size since that will simplify these tests
+        if (total_size % file_size) != 0:
+            raise ValueError('The default chunk size must be a multiple of '
+                             'the total size for the purpose of these tests.')
+        num_chunks = total_size // file_size
+        self.tuc.total_size = (file_size * num_chunks)
+        # Last chunk is incremented after each chunk is stored so it's
+        # effectively a 1-indexed value defining the total number of chunks.
+        # Chunk files are numbered from 1 too so last_chunk will be the
+        # number at the end of the filename in the last chunk file.
+        self.tuc.last_chunk = num_chunks
+
+        chunk_dir = self.test_file_loc + '/' + self.tuc.upload_dir
+        chunk_file_base = chunk_dir + '/' + self.tuc.file_id + '_'
+
+        join_list = [chunk_dir] + [
+            chunk_file_base+str(i) for i in range(1, self.tuc.last_chunk + 1)]
+
+        mock_data_info = {}
+        for i in range(1, num_chunks + 1):
+            mock_data_info[chunk_file_base + str(i)] = file_size
+
+        (mock_open_se, _) = self._init_file_tests(mock_data_info)
+
+        mock_os, mock_storage, _, _ = self._setup_mocks(
+            True, join_list=join_list)
+
+        with patch('django_drf_filepond.utils.os', mock_os):
+            with patch('django_drf_filepond.utils.storage', mock_storage):
+                with patch('builtins.open', side_effect=mock_open_se):
+                    f = DrfFilepondChunkedUploadedFile(
+                        self.tuc, 'application/octet-stream')
+                    self.assertEqual(f.first_file, self.first_file)
+                    f.open('rb')
+                    data = b''
+                    i = 1
+                    for c in f.chunks(chunk_size=read_chunk_size):
+                        LOG.debug('Read chunk %s, got <%s> bytes...'
+                                  % (str(i), str(len(c))))
+                        # Confirm that we read the expected default chunk size
+                        self.assertEqual(read_chunk_size, len(c))
                         data += c
+                        i += 1
                     f.close()
-        # Current chunk should be last chunk + 1
-        self.assertEqual(f.current_chunk, 10)
-        self.assertEqual(f.offset, (chunk_file_size * 8) + last_file_size)
-        mo.assert_called_once_with(self.first_file, 'rb')
 
-    def test_chunks_read_full_data_exact_chunk_multiple(self):
-        '''Test reading of a set of multiple chunk "files" that are each the
-           same size as the chunk size.'''
-        raise NotImplementedError('This test is not yet implemented.')
+    def _run_chunked_file_test(self, join_list, chunk_size, num_chunks,
+                               last_file_size, read_chunk_size=None):
+        chunk_file_size = chunk_size
 
-    def test_chunks_read_full_data_crossing_chunks(self):
-        '''Test reading of a set of multiple chunk "files" that are sized
-           differently to the chunk size, using a read chunk size that
-           ensures we cross chunk file boundaries during some reads.'''
-        raise NotImplementedError('This test is not yet implemented.')
+        mock_os, mock_storage, chunk_dir, first_file = self._setup_mocks(
+            True, join_list=join_list)
+        # Remove chunk number from first file
+        chunk_file_base = first_file[:-1]
+        mock_data_info = {}
+        for i in range(1, num_chunks + 1):
+            mock_data_info[chunk_file_base + str(i)] = (
+                chunk_file_size if i != num_chunks else last_file_size)
+
+        (mock_open_se, full_data) = self._init_file_tests(mock_data_info)
+
+        iterations = 0
+
+        with patch('django_drf_filepond.utils.os', mock_os):
+            with patch('django_drf_filepond.utils.storage', mock_storage):
+                with patch('builtins.open', side_effect=mock_open_se) as mo:
+                    f = DrfFilepondChunkedUploadedFile(
+                        self.tuc, 'application/octet-stream')
+                    self.assertEqual(f.first_file, self.first_file)
+                    f.open('rb')
+                    data = b''
+                    if read_chunk_size:
+                        for c in f.chunks(read_chunk_size):
+                            data += c
+                            iterations += 1
+                    else:
+                        for c in f.chunks():
+                            data += c
+                            iterations += 1
+                    f.close()
+
+        return (f, mo, iterations, data, full_data)

--- a/tests/test_load_view.py
+++ b/tests/test_load_view.py
@@ -9,7 +9,7 @@ import django_drf_filepond.drf_filepond_settings as local_settings
 import cgi
 import os
 import shutil
-import django_drf_filepond
+import django_drf_filepond.api
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/test_process_view.py
+++ b/tests/test_process_view.py
@@ -1,4 +1,4 @@
-from django_drf_filepond.models import TemporaryUploadChunked
+from django_drf_filepond.models import TemporaryUpload, TemporaryUploadChunked
 from io import BytesIO
 import logging
 import os
@@ -17,7 +17,7 @@ from six import ensure_text
 from django_drf_filepond import drf_filepond_settings
 import django_drf_filepond
 import django_drf_filepond.views as views
-from tests.utils import remove_file_upload_dir_if_required
+from tests.utils import prep_response, remove_file_upload_dir_if_required
 
 
 # Python 2/3 support
@@ -220,6 +220,9 @@ class ProcessTestCase(TestCase):
         views.storage = old_storage
         drf_filepond_settings.UPLOAD_TMP = old_UPLOAD_TMP
         drf_filepond_settings.ALLOW_EXTERNAL_UPLOAD_DIR = False
+        # Remove the TemporaryUpload object to remove the file created on
+        # disk by this test.
+        TemporaryUpload.objects.get(upload_id=response.data).delete()
         self.assertEqual(response.status_code, 200, 'Expecting upload to be '
                          'successful.')
 

--- a/tests/test_process_view.py
+++ b/tests/test_process_view.py
@@ -14,7 +14,7 @@ from rest_framework import status
 from rest_framework.response import Response
 from six import ensure_text
 
-from django_drf_filepond import drf_filepond_settings, uploaders
+from django_drf_filepond import drf_filepond_settings
 import django_drf_filepond
 import django_drf_filepond.views as views
 from tests.utils import remove_file_upload_dir_if_required
@@ -100,7 +100,7 @@ class ProcessTestCase(TestCase):
         (encoded_form, content_type) = self._get_encoded_form('testfile.dat')
 
         req = self.rf.post(reverse('process'),
-                      data=encoded_form, content_type=content_type)
+                           data=encoded_form, content_type=content_type)
         pv = views.ProcessView.as_view()
         response = pv(req)
 
@@ -115,7 +115,7 @@ class ProcessTestCase(TestCase):
         (encoded_form, content_type) = self._get_encoded_form('testfile.dat')
 
         req = self.rf.post(reverse('process'),
-                      data=encoded_form, content_type=content_type)
+                           data=encoded_form, content_type=content_type)
         pv = views.ProcessView.as_view()
         response = pv(req)
         views.storage = old_storage
@@ -132,7 +132,7 @@ class ProcessTestCase(TestCase):
                        SimpleUploadedFile('test.txt', self.test_data.read())}
         enc_form = encode_multipart('abc', upload_form)
         req = self.rf.post(reverse('process'), data=enc_form,
-                      content_type='multipart/form-data; boundary=abc')
+                           content_type='multipart/form-data; boundary=abc')
         pv = views.ProcessView.as_view()
         response = pv(req)
         self.assertEqual(response.status_code, 400, 'Expecting 400 error due'
@@ -147,7 +147,7 @@ class ProcessTestCase(TestCase):
         upload_form = {'filepond': cf}
         enc_form = encode_multipart('abc', upload_form)
         req = self.rf.post(reverse('process'), data=enc_form,
-                      content_type='multipart/form-data; boundary=abc')
+                           content_type='multipart/form-data; boundary=abc')
         req.FILES['filepond'] = cf
         pv = views.ProcessView.as_view()
         response = pv(req)
@@ -173,8 +173,8 @@ class ProcessTestCase(TestCase):
         enc_form = encode_multipart(boundary, upload_form)
 
         req = self.rf.post(reverse('process'), data=enc_form,
-                      content_type='multipart/form-data; boundary=%s'
-                      % boundary)
+                           content_type='multipart/form-data; boundary=%s'
+                           % boundary)
         pv = views.ProcessView.as_view()
         response = pv(req)
         self.assertEqual(response.status_code, 400, 'Expecting 400 error due'
@@ -190,7 +190,7 @@ class ProcessTestCase(TestCase):
         (encoded_form, content_type) = self._get_encoded_form('testfile.dat')
 
         req = self.rf.post(reverse('process'),
-                      data=encoded_form, content_type=content_type)
+                           data=encoded_form, content_type=content_type)
         pv = views.ProcessView.as_view()
         response = pv(req)
         views.storage = old_storage
@@ -214,7 +214,7 @@ class ProcessTestCase(TestCase):
         (encoded_form, content_type) = self._get_encoded_form('testfile.dat')
 
         req = self.rf.post(reverse('process'),
-                      data=encoded_form, content_type=content_type)
+                           data=encoded_form, content_type=content_type)
         pv = views.ProcessView.as_view()
         response = pv(req)
         views.storage = old_storage
@@ -232,7 +232,7 @@ class ProcessTestCase(TestCase):
         (encoded_form, content_type) = self._get_encoded_form('testfile.dat')
 
         req = self.rf.post(reverse('process'),
-                      data=encoded_form, content_type=content_type)
+                           data=encoded_form, content_type=content_type)
         pv = views.ProcessView.as_view()
         response = pv(req)
 

--- a/tests/test_revert_view.py
+++ b/tests/test_revert_view.py
@@ -103,7 +103,10 @@ class RevertTestCase(TestCase):
                             status_code=404)
 
     def test_revert_no_delete_dir(self):
+        # Store the DELETE_UPLOAD_TMP_DIRS value and re-set it at end of test.
+        old_del_tmp_dirs = local_settings.DELETE_UPLOAD_TMP_DIRS
         local_settings.DELETE_UPLOAD_TMP_DIRS = False
+        
         # Check that our record is in the database
         tu = TemporaryUpload.objects.get(upload_id=self.upload_id)
 
@@ -123,6 +126,7 @@ class RevertTestCase(TestCase):
                          'The test file wasn\'t removed.')
         self.assertTrue(os.path.exists(os.path.dirname(file_path)),
                         'The test file temp dir was unexpectedly removed.')
+        local_settings.DELETE_UPLOAD_TMP_DIRS = old_del_tmp_dirs
 
     def test_revert_delete_byte_data(self):
         upload_id = self.upload_id

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -32,6 +32,7 @@ class SignalsTestCase(TestCase):
         # Mock a TemporaryUpload instance object
         tu = Mock(spec=TemporaryUpload)
         upload_file = Mock(spec=SimpleUploadedFile)
+        original_models_storage = models.storage
         models.storage = Mock(spec=FileSystemStorage)
         models.storage.location = tmp_dir_split[0]
 
@@ -39,5 +40,6 @@ class SignalsTestCase(TestCase):
         tu.upload_id = tmp_dir_split[1]
         tu.file = upload_file
         delete_temp_upload_file(None, tu)
+        models.storage = original_models_storage
         self.assertFalse(os.path.exists(path), 'Test temp file was not '
                          'removed by the signal handler.')

--- a/tests/test_uploaders_base.py
+++ b/tests/test_uploaders_base.py
@@ -39,6 +39,10 @@ LOG = logging.getLogger(__name__)
 #    when we try to access a file from a request where the specfied custom
 #    field name is missing in the request.
 #
+# test_get_file_obj_custom_field_multiple_entries_error: Test that a Parse
+#    Error is generated when we are passed data that includes more than two
+#    values for the custom field name - we can only accept one or two items.
+#
 # test_get_uploader_patch_req: Test that a PATCH request results in a
 #    FilepondChunkedFileUploader being returned.
 #
@@ -50,6 +54,9 @@ LOG = logging.getLogger(__name__)
 #
 # test_get_uploader_post_req_chunk: Test that a chunked upload POST request
 #    results in a FilepondChunkedFileUploader being returned.
+#
+# test_handle_upload_invalid_method_error: Test that a call to handle_upload
+#    with an invalid method returns a 405 - method not supported - error.
 #
 # test_get_uploader_get_req: Test that a get request results in an exception
 #    since no uploader type currently supports get requests.
@@ -103,6 +110,14 @@ class UploadersBaseTestCase(TestCase):
                                                'a_field': '{}'})
         with self.assertRaisesMessage(
                 ParseError, 'Invalid request data has been provided.'):
+            FilepondFileUploader._get_file_obj(self.request)
+
+    def test_get_file_obj_custom_field_multiple_entries_error(self):
+        self.request.data = _setupRequestData(
+            {'fp_upload_field': 'somefield',
+             'somefield': ['{}', '{some data}', 'some other data']})
+        with self.assertRaisesMessage(
+                ParseError, 'Invalid number of fields in request data.'):
             FilepondFileUploader._get_file_obj(self.request)
 
     def test_get_uploader_patch_req(self):

--- a/tests/test_uploaders_chunked.py
+++ b/tests/test_uploaders_chunked.py
@@ -52,6 +52,9 @@ LOG = logging.getLogger(__name__)
 # test_valid_post_req_handled: Test that a valid POST request is handled
 #    correctly and results in calling _handle_new_chunk_upload
 #
+# test_invalid_method_error: Test that a call to handle_upload with an invalid
+#    method returns a 405 - method not supported - error.
+#
 #
 # TESTS FOR _handle_new_chunk_upload FUNCTION
 # -------------------------------------------
@@ -245,6 +248,16 @@ class UploadersFileChunkedTestCase(TestCase):
         self.uploader.handle_upload(self.request, self.upload_id, self.file_id)
         mock_hncu.assert_called_with(self.request, self.upload_id,
                                      self.file_id)
+
+    def test_invalid_method_error(self):
+        '''Test that a call to handle_upload with an invalid method
+           returns a 405 - method not supported - error.'''
+        self.request.method = 'DELETE'
+        self.request.data = _setupRequestData({'filepond': '{}'})
+        r = self.uploader.handle_upload(self.request, self.upload_id,
+                                        self.file_id)
+        r = self._prep_response(r)
+        self.assertContains(r, 'Invalid method.', status_code=405)
 
     # TESTS FOR _handle_new_chunk_upload FUNCTION
     # -------------------------------------------

--- a/tests/test_uploaders_standard.py
+++ b/tests/test_uploaders_standard.py
@@ -64,11 +64,16 @@ class UploadersFileStandardTestCase(TestCase):
         r = self.uploader.handle_upload(self.request, self.upload_id,
                                         self.file_id)
         self.assertEqual(r.status_code, 200, 'Response status code is invalid')
-        self.assertEqual(r.data, self.upload_id, 'Response data is invalid')
+
         tu = TemporaryUpload.objects.get(upload_id=self.upload_id)
-        self.assertEqual(tu.file_id, self.file_id,
+        fileid = tu.file_id
+        uploadname = tu.upload_name
+        tu.delete()
+
+        self.assertEqual(r.data, self.upload_id, 'Response data is invalid')
+        self.assertEqual(fileid, self.file_id,
                          'The TemporaryUpload stored file_id is not correct.')
-        self.assertEqual(tu.upload_name, self.file_name,
+        self.assertEqual(uploadname, self.file_name,
                          'The TemporaryUpload upload_name is not correct.')
 
     def test_handle_file_upload_invalid_upload_id(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 # Some util functions for django-drf-filepond tests
+from django_drf_filepond.renderers import PlainTextRenderer
 import logging
 import os
 from django.http.request import QueryDict
@@ -32,3 +33,15 @@ def _setupRequestData(value_dict):
         else:
             qd.update({key: val})
     return qd
+
+
+# Since we're working with mocked requests and getting responses that
+# haven't been processed via a DRF/Django view, the response won't render
+# correctly without having some additional parameters set. Using
+# assertContains requires that the request has these parameters set so
+# this helper function is used to avoid repetition.
+def prep_response(response):
+    response.accepted_renderer = PlainTextRenderer()
+    response.accepted_media_type = 'text/plain'
+    response.renderer_context = {}
+    return response


### PR DESCRIPTION
This update addresses issue #64 by adding a new `DrfFilepondChunkedUploadedFile` object that is a specialisation of `django.core.files.uploadedfile.UploadedFile`. This new object avoids the need to separately combine file chunks in memory when creating a complete file object for storage.

Previously, we combined all the file chunks in a `BytesIO` object and then used this as a the basis for an [`InMemoryUploadedFile`](https://docs.djangoproject.com/en/3.2/ref/files/uploads/#django.core.files.uploadedfile.InMemoryUploadedFile) object. This resulted in the content of the `BytesIO` object being copied and resulting in two in-memory copies of the data and double the memory usage of the individual file size. For large uploads this presents an issue as highlighted in #64.

The new object can be passed directly to a TeporaryUpload obejct for saving. When the file content is read, the logic in the `DrfFilepondChunkedUploadedFile` object handles opening the relevant chunk file on disk and returning the requested data. This should resolve the issue of high memory usage.