### PR TITLE
Minor PEP8 formatting fixes

### DIFF
--- a/django_drf_filepond/api.py
+++ b/django_drf_filepond/api.py
@@ -130,7 +130,7 @@ def _store_upload_local(destination_file_path, destination_file_name,
 
     # Is this necessary? Checking on every file storage in case the directory
     # was removed but not sure that this is really necessary.
-    if((not os.path.exists(file_path_base)) or
+    if ((not os.path.exists(file_path_base)) or
             (not os.path.isdir(file_path_base))):
         raise FileNotFoundError(
             'The local output directory [%s] defined by FILE_STORE_PATH is '

--- a/django_drf_filepond/models.py
+++ b/django_drf_filepond/models.py
@@ -180,8 +180,9 @@ def delete_temp_upload_file(sender, instance, **kwargs):
                 os.path.isfile(instance.file.path)):
             os.remove(instance.file.path)
 
-    LOG.debug('*** post_delete <%s> - Value of DELETE_UPLOAD_TMP_DIRS: %s'
-              % (instance.upload_id, str(local_settings.DELETE_UPLOAD_TMP_DIRS)))
+    LOG.debug(
+        '*** post_delete <%s> - Value of DELETE_UPLOAD_TMP_DIRS: %s'
+        % (instance.upload_id, str(local_settings.DELETE_UPLOAD_TMP_DIRS)))
     if local_settings.DELETE_UPLOAD_TMP_DIRS:
         file_dir = os.path.join(storage.location, instance.upload_id)
         if (os.path.exists(file_dir) and os.path.isdir(file_dir)):

--- a/django_drf_filepond/uploaders.py
+++ b/django_drf_filepond/uploaders.py
@@ -6,7 +6,7 @@ from rest_framework import status
 from rest_framework.exceptions import ParseError, MethodNotAllowed
 from rest_framework.response import Response
 
-from django_drf_filepond.models import TemporaryUpload, storage,\
+from django_drf_filepond.models import TemporaryUpload, storage, \
     TemporaryUploadChunked
 from io import BytesIO, StringIO
 from django_drf_filepond.utils import DrfFilepondChunkedUploadedFile, _get_user
@@ -61,7 +61,8 @@ class FilepondFileUploader(object):
             upload_field_name = request.data['fp_upload_field']
 
         if upload_field_name not in request.data:
-            raise ParseError('Could not find upload_field_name in request data.')
+            raise ParseError(
+                'Could not find upload_field_name in request data.')
 
         # The content of the upload field is a django.http.QueryDict.
         # The dict may have multiple values for a given field name.

--- a/django_drf_filepond/urls.py
+++ b/django_drf_filepond/urls.py
@@ -9,7 +9,7 @@ if six.PY2:
     from django.conf.urls import url
 else:
     from django.urls import re_path, path
-from django_drf_filepond.views import ProcessView, RevertView, LoadView,\
+from django_drf_filepond.views import ProcessView, RevertView, LoadView, \
      RestoreView, FetchView, PatchView
 
 #############################################################################

--- a/django_drf_filepond/views.py
+++ b/django_drf_filepond/views.py
@@ -30,7 +30,7 @@ from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from django_drf_filepond.uploaders import FilepondFileUploader
-from django_drf_filepond.utils import _get_file_id, _get_user,\
+from django_drf_filepond.utils import _get_file_id, _get_user, \
     get_local_settings_base_dir
 
 LOG = logging.getLogger(__name__)


### PR DESCRIPTION
A few minor formatting fixes to address PEP8 errors. This relates to #89 since `flake8` is now being run in the Actions workflow.

Closes #89.