### PR TITLE
Move checking for missing file store config to API functions

### DIFF
--- a/django_drf_filepond/api.py
+++ b/django_drf_filepond/api.py
@@ -210,8 +210,6 @@ def get_stored_upload(upload_id):
     upload_id: This function takes a 22-character unique ID assigned to the
     original upload of the requested file.
     """
-    _check_file_store_config_provided()
-
     # If the parameter matched the upload ID format, we assume that it
     # must be an upload ID and proceed accordingly. If the lookup of the
     # record fails, then we have another go assuming a filename was

--- a/django_drf_filepond/api.py
+++ b/django_drf_filepond/api.py
@@ -69,6 +69,8 @@ def store_upload(upload_id, destination_file_path):
     file. i.e. the file will be stored at
         destination_file_path + destination_file_name
     """
+    _check_file_store_config_provided()
+
     # TODO: If the storage backend is not initialised, init now - this will
     # be removed when this module is refactored into a class.
     if not storage_backend_initialised:
@@ -208,6 +210,8 @@ def get_stored_upload(upload_id):
     upload_id: This function takes a 22-character unique ID assigned to the
     original upload of the requested file.
     """
+    _check_file_store_config_provided()
+
     # If the parameter matched the upload ID format, we assume that it
     # must be an upload ID and proceed accordingly. If the lookup of the
     # record fails, then we have another go assuming a filename was
@@ -261,6 +265,8 @@ def get_stored_upload_file_data(stored_upload):
         filename is a string containing the name of the stored file
         data_bytes_io is a file-like BytesIO object containing the file data
     """
+    _check_file_store_config_provided()
+
     # TODO: If the storage backend is not initialised, init now - this
     # will be removed when this module is refactored into a class.
     if not storage_backend_initialised:
@@ -320,6 +326,8 @@ def delete_stored_upload(upload_id, delete_file=False):
     is made explicit that the stored file associated with the upload will be
     permanently deleted.
     """
+    _check_file_store_config_provided()
+
     try:
         su = get_stored_upload(upload_id)
     except StoredUpload.DoesNotExist as e:
@@ -386,3 +394,22 @@ def delete_stored_upload(upload_id, delete_file=False):
         # been created to store the file. For now, we just delete the file.
 
     return True
+
+# As noted in #97, there may be cases where permanent file storage of files
+# that have been uploaded from the filepond client is handled manually and
+# completely independently of django-drf-filepond. In these cases, the settings
+# related to file storage may not provided (DJANGO_DRF_FILEPONF_FILE_STORE_PATH
+# and DJANGO_DRF_FILEPOND_STORAGES_BACKEND). Note that this is independent of
+# the temporary uploads from the filepond client which are handled by
+# django-drf-filepond using a separate setting. Since the file storage options
+# are not required, the settings check at startup no longer throws an error
+# when they're not provided but we instead have to check for them here.
+def _check_file_store_config_provided():
+    file_store = getattr(local_settings, 'FILE_STORE_PATH', None)
+    storage_class = getattr(local_settings, 'STORAGES_BACKEND', None)
+    if (not file_store) and (not storage_class):
+        raise ImproperlyConfigured(
+            'The django-drf-filepond file storage API cannot be used since '
+            'configuration for either a local file storage directory or a '
+            'remote file storage service has not been provided. Please see '
+            'the documentation.')

--- a/django_drf_filepond/apps.py
+++ b/django_drf_filepond/apps.py
@@ -74,10 +74,17 @@ class DjangoDrfFilepondConfig(AppConfig):
                           'exists')
         else:
             if not storage_class:
-                LOG.error('You are using local file storage so you must set '
-                          'the base file storage path using %sFILE_STORE_PATH'
-                          % local_settings._app_prefix)
-                raise ImproperlyConfigured(
-                    'You are using local file storage so you must set the '
-                    'base file storage path using %sFILE_STORE_PATH'
-                    % local_settings._app_prefix)
+                # As highlighted in #97, it's possible that users of the
+                # library will want to handle permanent file storage manually.
+                # In this case, both FILE_STORE_PATH and STORAGES_BACKEND may
+                # remain unset. Rather than raising an error here, we now
+                # simply provide a warning and check for existence of one of
+                # the required configuration options when API calls are made.
+                LOG.warning(
+                    'You have not set either %sFILE_STORE_PATH or '
+                    '%sSTORAGES_BACKEND. It is assumed that you are handling '
+                    'permanent storage of files (after they are uploaded to '
+                    'django-drf-filepond from the filepond client) manually. '
+                    'If this is not the case, you need to set one of these '
+                    'settings.' %
+                    (local_settings._app_prefix, local_settings._app_prefix))

--- a/django_drf_filepond/apps.py
+++ b/django_drf_filepond/apps.py
@@ -4,7 +4,6 @@ import importlib
 import os
 import logging
 import django_drf_filepond.drf_filepond_settings as local_settings
-from django.core.exceptions import ImproperlyConfigured
 
 LOG = logging.getLogger(__name__)
 

--- a/django_drf_filepond/views.py
+++ b/django_drf_filepond/views.py
@@ -11,7 +11,7 @@ import re
 import requests
 import shortuuid
 import django_drf_filepond
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.validators import URLValidator
 from django.http.response import HttpResponse, HttpResponseNotFound, \
@@ -240,7 +240,7 @@ class LoadView(APIView):
         # su is now the StoredUpload record for the requested file
         try:
             (filename, data_bytes) = get_stored_upload_file_data(su)
-        except ConfigurationError as e:
+        except (ConfigurationError, ImproperlyConfigured) as e:
             LOG.error('Error getting file upload: [%s]' % str(e))
             return HttpResponseServerError('The file upload settings are '
                                            'not configured correctly.')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,15 +15,13 @@ store_upload:
 import logging
 import os
 
-from django.test import TestCase
-from django_drf_filepond.api import store_upload
-from django_drf_filepond.utils import _get_file_id
-from django.core.files.uploadedfile import SimpleUploadedFile
-from django_drf_filepond.models import TemporaryUpload, StoredUpload
-
 import django_drf_filepond.drf_filepond_settings as local_settings
 from django.core.exceptions import ImproperlyConfigured
-from django_drf_filepond.api import _store_upload_local
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from django_drf_filepond.api import _store_upload_local, store_upload
+from django_drf_filepond.models import StoredUpload, TemporaryUpload
+from django_drf_filepond.utils import _get_file_id
 
 # There's no built in FileNotFoundError, FileExistsError in Python 2
 try:
@@ -97,6 +95,10 @@ LOG = logging.getLogger(__name__)
 #
 # test_store_upload_local_copy_to_store_fails: Call _store_upload_local and
 #    the copy to permanent storage fails - expect exception.
+#
+# test_store_upload_without_config_set: Check that attempting to call
+#    store_upload without either a FILE_STORE_PATH or STORAGES_BACKEND set
+#    results in an IncorrectlyConfigured exception.
 #
 class ApiTestCase(TestCase):
 
@@ -349,6 +351,24 @@ class ApiTestCase(TestCase):
                             'storage location'):
                         _store_upload_local('/test_storage', 'testfile.txt',
                                             tu)
+    
+    def test_store_upload_without_config_set(self):
+        """
+        Check that attempting to call store_upload without either a
+        FILE_STORE_PATH or STORAGES_BACKEND set results in an
+        IncorrectlyConfigured exception.
+        """
+        file_store_path_bak = local_settings.FILE_STORE_PATH
+        storages_bak = local_settings.STORAGES_BACKEND
+        local_settings.FILE_STORE_PATH = None
+        local_settings.STORAGES_BACKEND = None
+        with self.assertRaisesMessage(
+                ImproperlyConfigured,
+                'Expepected an error since neither a file store location or '
+                'storages backend are set.'):
+            store_upload(self.upload_id, self.test_target_dirname)
+        local_settings.FILE_STORE_PATH = file_store_path_bak
+        local_settings.STORAGES_BACKEND = storages_bak
 
     def tearDown(self):
         upload_tmp_base = getattr(local_settings, 'UPLOAD_TMP', None)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -131,8 +131,11 @@ class ApiTestCase(TestCase):
         fsp = local_settings.FILE_STORE_PATH
         local_settings.FILE_STORE_PATH = None
         with self.assertRaisesMessage(
-                ImproperlyConfigured, 'A required setting is missing in '
-                'your application configuration.'):
+                ImproperlyConfigured,
+                'The django-drf-filepond file storage API cannot be used '
+                'since configuration for either a local file storage '
+                'directory or a remote file storage service has not been '
+                'provided. Please see the documentation.'):
             store_upload('hsdfiuysh78sdhiu', '/test_storage/test_file.txt')
         local_settings.FILE_STORE_PATH = fsp
 
@@ -362,13 +365,17 @@ class ApiTestCase(TestCase):
         storages_bak = local_settings.STORAGES_BACKEND
         local_settings.FILE_STORE_PATH = None
         local_settings.STORAGES_BACKEND = None
-        with self.assertRaisesMessage(
-                ImproperlyConfigured,
-                'Expepected an error since neither a file store location or '
-                'storages backend are set.'):
-            store_upload(self.upload_id, self.test_target_dirname)
-        local_settings.FILE_STORE_PATH = file_store_path_bak
-        local_settings.STORAGES_BACKEND = storages_bak
+        try:
+            with self.assertRaisesMessage(
+                    ImproperlyConfigured,
+                    'The django-drf-filepond file storage API cannot be used '
+                    'since configuration for either a local file storage '
+                    'directory or a remote file storage service has not been '
+                    'provided. Please see the documentation.'):
+                store_upload(self.upload_id, self.test_target_dirname)
+        finally:
+            local_settings.FILE_STORE_PATH = file_store_path_bak
+            local_settings.STORAGES_BACKEND = storages_bak
 
     def tearDown(self):
         upload_tmp_base = getattr(local_settings, 'UPLOAD_TMP', None)

--- a/tests/test_api_delete.py
+++ b/tests/test_api_delete.py
@@ -19,21 +19,19 @@ delete_stored_upload:
 import logging
 import os
 
-from django.test import TestCase
-from django_drf_filepond.utils import _get_file_id
-from django_drf_filepond.models import StoredUpload
-
 import django_drf_filepond.drf_filepond_settings as local_settings
+from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase
 from django.utils import timezone
 from django_drf_filepond.exceptions import ConfigurationError
+from django_drf_filepond.models import StoredUpload
+from django_drf_filepond.utils import _get_file_id
 
 # Python 2/3 support
 try:
-    from unittest.mock import MagicMock
-    from unittest.mock import patch
+    from unittest.mock import MagicMock, patch
 except ImportError:
-    from mock import MagicMock
-    from mock import patch
+    from mock import MagicMock, patch
 
 # There's no built in FileNotFoundError, FileExistsError in Python 2
 try:
@@ -86,6 +84,10 @@ LOG = logging.getLogger(__name__)
 #
 # test_delete_stored_upload_local_remove_fails: Call delete_stored_upload
 #    with a valid upload_id but where the file is missing on the local file
+#
+# test_delete_stored_upload_without_config_set: Check that attempting to call
+#    delete_stored_upload without either a FILE_STORE_PATH or STORAGES_BACKEND
+#    set results in an IncorrectlyConfigured exception.
 #
 class ApiDeleteTestCase(TestCase):
 
@@ -287,6 +289,24 @@ class ApiDeleteTestCase(TestCase):
                                                   'Error deleting file'):
                         self.delete_upload(self.upload_id, delete_file=True)
                     os_patcher.assert_called_once_with(file_location)
+
+    def test_delete_stored_upload_without_config_set(self):
+        """
+        Check that attempting to call delete_stored_upload without either a
+        FILE_STORE_PATH or STORAGES_BACKEND set results in an
+        IncorrectlyConfigured exception.
+        """
+        file_store_path_bak = local_settings.FILE_STORE_PATH
+        storages_bak = local_settings.STORAGES_BACKEND
+        local_settings.FILE_STORE_PATH = None
+        local_settings.STORAGES_BACKEND = None
+        with self.assertRaisesMessage(
+                ImproperlyConfigured,
+                'Expepected an error since neither a file store location or '
+                'storages backend are set.'):
+            self.delete_upload(self.upload_id)
+        local_settings.FILE_STORE_PATH = file_store_path_bak
+        local_settings.STORAGES_BACKEND = storages_bak
 
     def tearDown(self):
         local_settings.STORAGES_BACKEND = self.storage_backend

--- a/tests/test_api_delete.py
+++ b/tests/test_api_delete.py
@@ -208,8 +208,11 @@ class ApiDeleteTestCase(TestCase):
         local_settings.STORAGES_BACKEND = None
         self.api.storage_backend_initialised = False
         with self.assertRaisesMessage(
-                ConfigurationError,
-                'The file upload settings are not configured correctly.'):
+                ImproperlyConfigured,
+                'The django-drf-filepond file storage API cannot be used '
+                'since configuration for either a local file storage '
+                'directory or a remote file storage service has not been '
+                'provided. Please see the documentation.'):
             self.delete_upload(self.upload_id, delete_file=True)
         local_settings.FILE_STORE_PATH = fsp
 
@@ -300,13 +303,17 @@ class ApiDeleteTestCase(TestCase):
         storages_bak = local_settings.STORAGES_BACKEND
         local_settings.FILE_STORE_PATH = None
         local_settings.STORAGES_BACKEND = None
-        with self.assertRaisesMessage(
-                ImproperlyConfigured,
-                'Expepected an error since neither a file store location or '
-                'storages backend are set.'):
-            self.delete_upload(self.upload_id)
-        local_settings.FILE_STORE_PATH = file_store_path_bak
-        local_settings.STORAGES_BACKEND = storages_bak
+        try:
+            with self.assertRaisesMessage(
+                    ImproperlyConfigured,
+                    'The django-drf-filepond file storage API cannot be used '
+                    'since configuration for either a local file storage '
+                    'directory or a remote file storage service has not been '
+                    'provided. Please see the documentation.'):
+                self.delete_upload(self.upload_id)
+        finally:
+            local_settings.FILE_STORE_PATH = file_store_path_bak
+            local_settings.STORAGES_BACKEND = storages_bak
 
     def tearDown(self):
         local_settings.STORAGES_BACKEND = self.storage_backend

--- a/tests/test_api_getupload.py
+++ b/tests/test_api_getupload.py
@@ -54,10 +54,6 @@ LOG = logging.getLogger(__name__)
 # test_get_remote_upload_not_on_remote_store: Check that when requesting
 #    a file from a remote store that doesn't exist, we get a suitable error
 #
-# test_get_stored_upload_without_config_set: Check that attempting to call
-#    get_stored_upload without either a FILE_STORE_PATH or STORAGES_BACKEND set
-#    results in an IncorrectlyConfigured exception.
-#
 # test_get_stored_upload_file_data_without_config_set: Check that attempting to
 #    call get_stored_upload_file_data without either a FILE_STORE_PATH or
 #    STORAGES_BACKEND set results in an IncorrectlyConfigured exception.
@@ -107,8 +103,11 @@ class ApiGetUploadTestCase(TestCase):
         fsp = local_settings.FILE_STORE_PATH
         local_settings.FILE_STORE_PATH = None
         with self.assertRaisesMessage(
-                ConfigurationError,
-                'The file upload settings are not configured correctly.'):
+                ImproperlyConfigured,
+                'The django-drf-filepond file storage API cannot be used '
+                'since configuration for either a local file storage '
+                'directory or a remote file storage service has not been '
+                'provided. Please see the documentation.'):
             get_stored_upload_file_data(self.su)
         local_settings.FILE_STORE_PATH = fsp
 
@@ -185,24 +184,6 @@ class ApiGetUploadTestCase(TestCase):
         mock_storage_backend = django_drf_filepond.api.storage_backend
         return mock_storage_backend
 
-    def test_get_stored_upload_without_config_set(self):
-        """
-        Check that attempting to call get_stored_upload without either a
-        FILE_STORE_PATH or STORAGES_BACKEND set results in an
-        IncorrectlyConfigured exception.
-        """
-        file_store_path_bak = local_settings.FILE_STORE_PATH
-        storages_bak = local_settings.STORAGES_BACKEND
-        local_settings.FILE_STORE_PATH = None
-        local_settings.STORAGES_BACKEND = None
-        with self.assertRaisesMessage(
-                ImproperlyConfigured,
-                'Expepected an error since neither a file store location or '
-                'storages backend are set.'):
-            get_stored_upload(self.upload_id)
-        local_settings.FILE_STORE_PATH = file_store_path_bak
-        local_settings.STORAGES_BACKEND = storages_bak
-
     def test_get_stored_upload_file_data_without_config_set(self):
         """
         Check that attempting to call get_stored_upload_file_data without
@@ -213,13 +194,17 @@ class ApiGetUploadTestCase(TestCase):
         storages_bak = local_settings.STORAGES_BACKEND
         local_settings.FILE_STORE_PATH = None
         local_settings.STORAGES_BACKEND = None
-        with self.assertRaisesMessage(
-                ImproperlyConfigured,
-                'Expepected an error since neither a file store location or '
-                'storages backend are set.'):
-            get_stored_upload_file_data(self.su)
-        local_settings.FILE_STORE_PATH = file_store_path_bak
-        local_settings.STORAGES_BACKEND = storages_bak
+        try:
+            with self.assertRaisesMessage(
+                    ImproperlyConfigured,
+                    'The django-drf-filepond file storage API cannot be used '
+                    'since configuration for either a local file storage '
+                    'directory or a remote file storage service has not been '
+                    'provided. Please see the documentation.'):
+                get_stored_upload_file_data(self.su)
+        finally:
+            local_settings.FILE_STORE_PATH = file_store_path_bak
+            local_settings.STORAGES_BACKEND = storages_bak
     
     def tearDown(self):
         # Delete stored upload

--- a/tests/test_api_getupload.py
+++ b/tests/test_api_getupload.py
@@ -6,18 +6,17 @@ Testing of:
     get_stored_upload
     get_stored_upload_file_data
 '''
-from io import BytesIO
 import logging
 import os
-
-from django.test import TestCase
-from django.utils import timezone
-
-from django_drf_filepond.api import get_stored_upload, \
-    get_stored_upload_file_data
+from io import BytesIO
 
 import django_drf_filepond.api
 import django_drf_filepond.drf_filepond_settings as local_settings
+from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase
+from django.utils import timezone
+from django_drf_filepond.api import (get_stored_upload,
+                                     get_stored_upload_file_data)
 from django_drf_filepond.exceptions import ConfigurationError
 from django_drf_filepond.models import StoredUpload
 from django_drf_filepond.utils import _get_file_id
@@ -54,6 +53,14 @@ LOG = logging.getLogger(__name__)
 #
 # test_get_remote_upload_not_on_remote_store: Check that when requesting
 #    a file from a remote store that doesn't exist, we get a suitable error
+#
+# test_get_stored_upload_without_config_set: Check that attempting to call
+#    get_stored_upload without either a FILE_STORE_PATH or STORAGES_BACKEND set
+#    results in an IncorrectlyConfigured exception.
+#
+# test_get_stored_upload_file_data_without_config_set: Check that attempting to
+#    call get_stored_upload_file_data without either a FILE_STORE_PATH or
+#    STORAGES_BACKEND set results in an IncorrectlyConfigured exception.
 #
 class ApiGetUploadTestCase(TestCase):
 
@@ -178,6 +185,42 @@ class ApiGetUploadTestCase(TestCase):
         mock_storage_backend = django_drf_filepond.api.storage_backend
         return mock_storage_backend
 
+    def test_get_stored_upload_without_config_set(self):
+        """
+        Check that attempting to call get_stored_upload without either a
+        FILE_STORE_PATH or STORAGES_BACKEND set results in an
+        IncorrectlyConfigured exception.
+        """
+        file_store_path_bak = local_settings.FILE_STORE_PATH
+        storages_bak = local_settings.STORAGES_BACKEND
+        local_settings.FILE_STORE_PATH = None
+        local_settings.STORAGES_BACKEND = None
+        with self.assertRaisesMessage(
+                ImproperlyConfigured,
+                'Expepected an error since neither a file store location or '
+                'storages backend are set.'):
+            get_stored_upload(self.upload_id)
+        local_settings.FILE_STORE_PATH = file_store_path_bak
+        local_settings.STORAGES_BACKEND = storages_bak
+
+    def test_get_stored_upload_file_data_without_config_set(self):
+        """
+        Check that attempting to call get_stored_upload_file_data without
+        either a FILE_STORE_PATH or STORAGES_BACKEND set results in an
+        IncorrectlyConfigured exception.
+        """
+        file_store_path_bak = local_settings.FILE_STORE_PATH
+        storages_bak = local_settings.STORAGES_BACKEND
+        local_settings.FILE_STORE_PATH = None
+        local_settings.STORAGES_BACKEND = None
+        with self.assertRaisesMessage(
+                ImproperlyConfigured,
+                'Expepected an error since neither a file store location or '
+                'storages backend are set.'):
+            get_stored_upload_file_data(self.su)
+        local_settings.FILE_STORE_PATH = file_store_path_bak
+        local_settings.STORAGES_BACKEND = storages_bak
+    
     def tearDown(self):
         # Delete stored upload
         self.su.delete()


### PR DESCRIPTION
This is being done to address issue #97 which highlights that having neither a `FILE_STORE_PATH` or `STORAGES_BACKEND` set is a valid case if file storage is being handled manually. To address this, checking for these parameters is pushed down to the API function calls where they're used.