### PR TITLE
Add support for filenames that use non-ASCII characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,14 @@ See full details of the particular changes merged in the [v0.5.0 release notes o
 
 ### License
 
-This repository is licensed under a BSD 3-Clause license. Please see the [LICENSE](LICENSE) file in the root of the repository.
+This repository is licensed under a BSD 3-Clause license. Please see the
+[LICENSE](LICENSE) file in the root of the repository.
+
+This project contains one function `content_disposition_header` (in
+`django_utils.py`) that is adapted from code in the Django project. The
+original code that this function is adapted from is Copyright (c) Django
+Software Foundation and individual contributors; All Rights Reserved;
+
 
 ### Acknowledgements
 

--- a/django_drf_filepond/django_utils.py
+++ b/django_drf_filepond/django_utils.py
@@ -1,0 +1,37 @@
+###########################################################################
+# Django's content_disposition_header function, as included in Django 4.2
+# The function is being reproduced here with modifications to support it's 
+# use with earlier versions of Django. 
+# The original code is available at:
+# https://docs.djangoproject.com/en/4.2/_modules/django/utils/http/#content_disposition_header
+# and via github in the django.utils.http module:
+# https://github.com/django/django/blob/main/django/utils/http.py#L357
+# The original code on which the function below is base is released under a
+# BSD-3-Clauselicence and is Copyright (c) Django Software Foundation and
+# individual contributors; All Rights Reserved; See Django LICENSE file at:
+# https://github.com/django/django/blob/main/LICENSE
+###########################################################################
+from urllib.parse import quote
+
+def content_disposition_header(as_attachment, filename):
+    """
+    Construct a Content-Disposition HTTP header value from the given filename
+    as specified by RFC 6266.
+    """
+    if filename:
+        disposition = "attachment" if as_attachment else "inline"
+        try:
+            filename.encode("ascii")
+            file_expr = 'filename="{}"'.format(
+                filename.replace("\\", "\\\\").replace('"', r"\"")
+            )
+        except UnicodeEncodeError:
+            file_expr = "filename*=utf-8''{}".format(quote(filename))
+        return ("%s; %s" % (disposition, file_expr))
+    elif as_attachment:
+        return "attachment"
+    else:
+        return None
+###########################################################################
+# End of Django code
+###########################################################################

--- a/django_drf_filepond/django_utils.py
+++ b/django_drf_filepond/django_utils.py
@@ -1,17 +1,29 @@
 ###########################################################################
-# Django's content_disposition_header function, as included in Django 4.2
-# The function is being reproduced here with modifications to support it's 
-# use with earlier versions of Django. 
+# This code is based on Django's content_disposition_header function, as
+# included in Django 4.2
+#
+# The function is being reproduced here with modifications to support it's
+# use with earlier versions of Django.
 # The original code is available at:
 # https://docs.djangoproject.com/en/4.2/_modules/django/utils/http/#content_disposition_header
 # and via github in the django.utils.http module:
 # https://github.com/django/django/blob/main/django/utils/http.py#L357
-# The original code on which the function below is base is released under a
-# BSD-3-Clauselicence and is Copyright (c) Django Software Foundation and
-# individual contributors; All Rights Reserved; See Django LICENSE file at:
+#
+# The original code on which the function below is based is released under a
+# BSD-3-Clause licence and is
+#
+# Copyright (c) Django Software Foundation and individual contributors;
+# All Rights Reserved;
+#
+# See Django LICENSE file at:
 # https://github.com/django/django/blob/main/LICENSE
 ###########################################################################
-from urllib.parse import quote
+import six
+if six.PY2:
+    from urllib import quote
+else:
+    from urllib.parse import quote
+
 
 def content_disposition_header(as_attachment, filename):
     """
@@ -26,6 +38,8 @@ def content_disposition_header(as_attachment, filename):
                 filename.replace("\\", "\\\\").replace('"', r"\"")
             )
         except UnicodeEncodeError:
+            # Support for PY2.7 - urlencode unicode object
+            filename = filename.encode('utf-8')
             file_expr = "filename*=utf-8''{}".format(quote(filename))
         return ("%s; %s" % (disposition, file_expr))
     elif as_attachment:

--- a/django_drf_filepond/views.py
+++ b/django_drf_filepond/views.py
@@ -16,6 +16,7 @@ from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.validators import URLValidator
 from django.http.response import HttpResponse, HttpResponseNotFound, \
     HttpResponseServerError
+from django.utils.encoding import escape_uri_path
 from django_drf_filepond.api import get_stored_upload, \
     get_stored_upload_file_data
 from django_drf_filepond.exceptions import ConfigurationError
@@ -29,6 +30,7 @@ from rest_framework.exceptions import ParseError, NotFound
 from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
 from django_drf_filepond.uploaders import FilepondFileUploader
 from django_drf_filepond.utils import _get_file_id, _get_user,\
     get_local_settings_base_dir
@@ -252,8 +254,8 @@ class LoadView(APIView):
         ct = _get_content_type(filename)
 
         response = HttpResponse(data_bytes, content_type=ct)
-        response['Content-Disposition'] = ('inline; filename=%s' %
-                                           filename)
+        response['Content-Disposition'] = ('inline; filename="%s"' %
+                                           escape_uri_path(filename))
 
         return response
 
@@ -296,8 +298,8 @@ class RestoreView(APIView):
         ct = _get_content_type(upload_file_name)
 
         response = HttpResponse(data, content_type=ct)
-        response['Content-Disposition'] = ('inline; filename=%s' %
-                                           upload_file_name)
+        response['Content-Disposition'] = ('inline; filename="%s"' %
+                                           escape_uri_path(upload_file_name))
 
         return response
 
@@ -419,8 +421,8 @@ class FetchView(APIView):
         response['Content-Type'] = content_type
         response['Content-Length'] = file_size
         response['X-Content-Transfer-Id'] = upload_id
-        response['Content-Disposition'] = ('inline; filename=%s' %
-                                           upload_file_name)
+        response['Content-Disposition'] = ('inline; filename="%s"' %
+                                           escape_uri_path(upload_file_name))
         return response
 
     def get(self, request):
@@ -432,6 +434,6 @@ class FetchView(APIView):
         else:
             raise ValueError('process_request result is of an unexpected type')
         response = HttpResponse(buf.getvalue(), content_type=content_type)
-        response['Content-Disposition'] = ('inline; filename=%s' %
-                                           upload_file_name)
+        response['Content-Disposition'] = ('inline; filename="%s"' %
+                                           escape_uri_path(upload_file_name))
         return response

--- a/django_drf_filepond/views.py
+++ b/django_drf_filepond/views.py
@@ -16,7 +16,6 @@ from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.validators import URLValidator
 from django.http.response import HttpResponse, HttpResponseNotFound, \
     HttpResponseServerError
-from django.utils.encoding import escape_uri_path
 from django_drf_filepond.api import get_stored_upload, \
     get_stored_upload_file_data
 from django_drf_filepond.exceptions import ConfigurationError
@@ -30,7 +29,6 @@ from rest_framework.exceptions import ParseError, NotFound
 from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
 from rest_framework.views import APIView
-
 from django_drf_filepond.uploaders import FilepondFileUploader
 from django_drf_filepond.utils import _get_file_id, _get_user,\
     get_local_settings_base_dir
@@ -39,6 +37,13 @@ LOG = logging.getLogger(__name__)
 
 LOAD_RESTORE_PARAM_NAME = 'id'
 
+# Django's content_disposition_header function is only
+# available in Django 4.2+, a local version is available to
+# support older Django versions
+try:
+    from django.utils.http import content_disposition_header
+except ImportError:
+    from django_drf_filepond.django_utils import content_disposition_header
 
 # There's no built in FileNotFoundError in Python 2
 try:
@@ -254,8 +259,8 @@ class LoadView(APIView):
         ct = _get_content_type(filename)
 
         response = HttpResponse(data_bytes, content_type=ct)
-        response['Content-Disposition'] = ('inline; filename="%s"' %
-                                           escape_uri_path(filename))
+        response['Content-Disposition'] = content_disposition_header(
+            False, filename)
 
         return response
 
@@ -298,8 +303,8 @@ class RestoreView(APIView):
         ct = _get_content_type(upload_file_name)
 
         response = HttpResponse(data, content_type=ct)
-        response['Content-Disposition'] = ('inline; filename="%s"' %
-                                           escape_uri_path(upload_file_name))
+        response['Content-Disposition'] = content_disposition_header(
+            False, upload_file_name)
 
         return response
 
@@ -421,8 +426,8 @@ class FetchView(APIView):
         response['Content-Type'] = content_type
         response['Content-Length'] = file_size
         response['X-Content-Transfer-Id'] = upload_id
-        response['Content-Disposition'] = ('inline; filename="%s"' %
-                                           escape_uri_path(upload_file_name))
+        response['Content-Disposition'] = content_disposition_header(
+            False, upload_file_name)
         return response
 
     def get(self, request):
@@ -434,6 +439,6 @@ class FetchView(APIView):
         else:
             raise ValueError('process_request result is of an unexpected type')
         response = HttpResponse(buf.getvalue(), content_type=content_type)
-        response['Content-Disposition'] = ('inline; filename="%s"' %
-                                           escape_uri_path(upload_file_name))
+        response['Content-Disposition'] = content_disposition_header(
+            False, upload_file_name)
         return response

--- a/tests/test_load_view.py
+++ b/tests/test_load_view.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import shutil
+import urllib
 # Switched to using Message rather than cgi.parse_header for parsing and
 # checking header params since cgi is deprecated and will be removed in py3.13
 from email.message import Message
@@ -47,6 +48,10 @@ LOG = logging.getLogger(__name__)
 # test_load_filename_successful_request: Make a GET request to the load
 #     endpoint with a filename. The request is successful.
 #
+# test_load_filename_non_ascii_successful_request: Test for correct handling of
+#     a GET request to the load endpoint with a filename that contains
+#     non-ascii characters.
+#
 # test_load_ambiguous_id_file: Make a GET request to the load endpoint
 #     a 22-character ID in the URL query string that is a file name.
 class LoadTestCase(TestCase):
@@ -62,10 +67,22 @@ class LoadTestCase(TestCase):
 
         msg = Message()
         msg['content-type'] = response['Content-Disposition']
-        self.assertTrue(
-            msg.get_param('filename'),
-            'Content-Disposition header doesn\'t contain filename parameter')
         fname = msg.get_param('filename')
+        self.assertTrue(
+            fname,
+            'Content-Disposition header doesn\'t contain filename parameter')
+
+        # If fname is a tuple then we're handling an encoded filename - this
+        # should be UTF-8 encoded. the Message library applies a latin-1
+        # decoding to the filename which we don't want so we need to reverse
+        # this before comparing the filename.
+        if type(fname) is tuple:
+            self.assertTrue(
+                fname[0].lower() == 'utf-8',
+                'Handling an encoded filename and expected UTF-8 encoding')
+            fname = urllib.parse.quote(fname[2], encoding='latin-1')
+            # Now UTF-8 decode to get the original filename for comparison!
+            fname = urllib.parse.unquote(fname, encoding='utf-8')
 
         self.assertEqual(filename, fname, ('Returned filename is not '
                          'equal to the provided filename value.'))
@@ -164,6 +181,35 @@ class LoadTestCase(TestCase):
 
         response = self.client.get((reverse('load') + '?id=%s' % self.fn))
         self._check_file_response(response, self.fn, self.file_content)
+
+    def test_load_filename_non_ascii_successful_request(self):
+        upload_id = _get_file_id()
+        file_id = _get_file_id()
+        file_content = ('This is some test file data for an uploaded file '
+                        'with a filename that contains non-ASCII characters.')
+        fn = 'тест.txt'
+        uploaded_file = SimpleUploadedFile(fn,
+                                           str.encode(file_content))
+        tu = TemporaryUpload(upload_id=upload_id,
+                             file_id=file_id,
+                             file=uploaded_file, upload_name=fn,
+                             upload_type=TemporaryUpload.FILE_DATA)
+        tu.save()
+
+        # Now set up a stored version of this upload
+        su = StoredUpload(upload_id=upload_id,
+                          file=('%s' % (fn)),
+                          uploaded=tu.uploaded)
+        su.save()
+        su_target_dir = os.path.join(LoadTestCase.FILE_STORE_PATH,
+                                     os.path.dirname(su.file.name))
+        if not os.path.exists(su_target_dir):
+            os.mkdir(su_target_dir)
+        shutil.copy2(tu.get_file_path(), os.path.join(
+            LoadTestCase.FILE_STORE_PATH, su.file.name))
+
+        response = self.client.get((reverse('load') + '?id=%s' % fn))
+        self._check_file_response(response, fn, file_content)
 
     def test_load_ambiguous_id_file(self):
         su = StoredUpload.objects.get(upload_id=self.upload_id)


### PR DESCRIPTION
This PR addresses issues with handling filenames that include non-ASCII characters. It resolves the issue originally reported by @roman-tiukh - thanks for opening the original PR for this.